### PR TITLE
fix: resolve pytest-django incompatibility by overriding django_db_setup

### DIFF
--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -47,11 +47,8 @@ def django_db_setup(
         # Reconfigure connections with updated settings
         connections._settings = connections.configure_settings(settings.DATABASES)
 
-        # Recreate connections for each database alias that was updated
-        for alias in list(connections):
-            if alias in connections._connections:
-                connections._connections[alias].close()
-            connections._connections[alias] = connections.create_connection(alias)
+        # Close all existing connections so they'll be recreated with new settings
+        connections.close_all()
 
         for provider_name in _container_manager.active_containers.keys():
             print(f"Started {provider_name} container for testing")

--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -47,11 +47,12 @@ def django_db_setup(
         # Reconfigure connections with updated settings
         connections._settings = connections.configure_settings(settings.DATABASES)
 
-        # Close all existing connections so they'll be recreated with new settings
+        # Close all existing connections
         connections.close_all()
 
-        for provider_name in _container_manager.active_containers.keys():
-            print(f"Started {provider_name} container for testing")
+        # Explicitly recreate connections with new settings
+        for alias in settings.DATABASES:
+            connections[alias] = connections.create_connection(alias)
 
     # Now run pytest-django's database setup logic
     from django.test.utils import setup_databases, teardown_databases

--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -1,8 +1,6 @@
-from collections.abc import Generator
 from typing import Any
 
 import pytest
-from django.conf import settings
 
 from .manager import ContainerManager
 
@@ -10,41 +8,54 @@ _container_manager: ContainerManager | None = None
 _original_settings: dict[str, Any] = {}
 
 
-@pytest.fixture(scope="session", autouse=True)
-def django_testcontainers_setup(
-    django_db_setup: Any,
-) -> Generator[ContainerManager, None, None]:
-    """Automatically start and stop testcontainers for the test session.
+@pytest.hookimpl(trylast=True)
+def pytest_load_initial_conftests(
+    early_config: pytest.Config,
+    parser: pytest.Parser,
+    args: list[str],
+) -> None:
+    """Start testcontainers early in pytest lifecycle.
 
-    This fixture:
-    1. Runs before any tests
-    2. Detects needed containers from Django settings
-    3. Starts the containers
-    4. Updates Django settings with connection info
-    5. Cleans up containers after all tests complete
+    This hook runs after pytest-django configures DJANGO_SETTINGS_MODULE
+    (due to trylast=True) but before any fixtures execute, ensuring
+    containers are ready and settings are patched before django_db_setup.
 
     Args:
-        django_db_setup: pytest-django fixture that sets up databases
-
-    Yields:
-        ContainerManager instance with active containers
+        early_config: The pytest config object
+        parser: The pytest parser
+        args: Command line arguments
     """
     global _container_manager, _original_settings
 
-    _container_manager = ContainerManager(settings)
+    from django.conf import settings
 
+    if not settings.configured:
+        return
+
+    _container_manager = ContainerManager(settings)
     settings_updates = _container_manager.start_containers()
 
-    _apply_settings_updates(settings_updates)
+    _apply_settings_updates(settings, settings_updates)
 
     for provider_name in _container_manager.active_containers.keys():
         print(f"Started {provider_name} container for testing")
 
-    yield _container_manager
 
-    _restore_settings()
-    print("Stopping test containers...")
-    _container_manager.stop_containers()
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Stop testcontainers when pytest exits.
+
+    Args:
+        config: The pytest config object
+    """
+    global _container_manager, _original_settings
+
+    if _container_manager is not None:
+        from django.conf import settings
+
+        _restore_settings(settings)
+        print("Stopping test containers...")
+        _container_manager.stop_containers()
+        _container_manager = None
 
 
 @pytest.fixture(scope="session")
@@ -57,10 +68,11 @@ def testcontainers_manager() -> ContainerManager | None:
     return _container_manager
 
 
-def _apply_settings_updates(updates: dict[str, Any]) -> None:
+def _apply_settings_updates(settings: Any, updates: dict[str, Any]) -> None:
     """Apply settings updates and save originals for restoration.
 
     Args:
+        settings: Django settings module
         updates: Dict of settings to update
     """
     global _original_settings
@@ -80,13 +92,14 @@ def _apply_settings_updates(updates: dict[str, Any]) -> None:
             setattr(settings, key, value)
 
 
-def _restore_settings() -> None:
-    """Restore original settings values."""
+def _restore_settings(settings: Any) -> None:
+    """Restore original settings values.
+
+    Args:
+        settings: Django settings module
+    """
     global _original_settings
 
     for key, value in _original_settings.items():
         setattr(settings, key, value)
     _original_settings.clear()
-
-
-pytest_plugins = ["django_testcontainers_plus.pytest_plugin"]

--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 from django.conf import settings
+from django.db import connections
 
 from .manager import ContainerManager
 
@@ -10,41 +11,80 @@ _container_manager: ContainerManager | None = None
 _original_settings: dict[str, Any] = {}
 
 
-@pytest.fixture(scope="session", autouse=True)
-def django_testcontainers_setup(
-    django_db_setup: Any,
-) -> Generator[ContainerManager, None, None]:
-    """Automatically start and stop testcontainers for the test session.
+@pytest.fixture(scope="session")
+def django_db_setup(
+    request: pytest.FixtureRequest,
+    django_test_environment: Any,
+    django_db_blocker: Any,
+    django_db_use_migrations: bool,
+    django_db_keepdb: bool,
+    django_db_createdb: bool,
+    django_db_modify_db_settings: None,
+) -> Generator[None, None, None]:
+    """Override pytest-django's django_db_setup to start containers first.
 
     This fixture:
-    1. Runs before any tests
-    2. Detects needed containers from Django settings
-    3. Starts the containers
-    4. Updates Django settings with connection info
+    1. Starts testcontainers before database setup
+    2. Clears Django's connection cache to pick up new settings
+    3. Reconfigures database connections with container settings
+    4. Sets up the test database using pytest-django's logic
     5. Cleans up containers after all tests complete
-
-    Args:
-        django_db_setup: pytest-django fixture that sets up databases
-
-    Yields:
-        ContainerManager instance with active containers
     """
     global _container_manager, _original_settings
 
+    # Start containers and get settings updates
     _container_manager = ContainerManager(settings)
-
     settings_updates = _container_manager.start_containers()
 
-    _apply_settings_updates(settings_updates)
+    if settings_updates:
+        # Apply settings updates
+        _apply_settings_updates(settings_updates)
 
-    for provider_name in _container_manager.active_containers.keys():
-        print(f"Started {provider_name} container for testing")
+        # Clear Django's cached connection settings
+        if "settings" in connections.__dict__:
+            del connections.__dict__["settings"]
 
-    yield _container_manager
+        # Reconfigure connections with updated settings
+        connections._settings = connections.configure_settings(settings.DATABASES)
 
-    _restore_settings()
-    print("Stopping test containers...")
-    _container_manager.stop_containers()
+        # Recreate connections for each database alias that was updated
+        for alias in list(connections):
+            if alias in connections._connections:
+                connections._connections[alias].close()
+            connections._connections[alias] = connections.create_connection(alias)
+
+        for provider_name in _container_manager.active_containers.keys():
+            print(f"Started {provider_name} container for testing")
+
+    # Now run pytest-django's database setup logic
+    from django.test.utils import setup_databases, teardown_databases
+
+    with django_db_blocker.unblock():
+        db_cfg = setup_databases(
+            verbosity=request.config.option.verbose,
+            interactive=False,
+            keepdb=django_db_keepdb,
+            debug_sql=request.config.option.debug_sql if hasattr(request.config.option, 'debug_sql') else False,
+            parallel=0,
+            aliases=None,
+            serialized_aliases=None,
+            run_migrations=django_db_use_migrations,
+        )
+
+    yield
+
+    # Teardown
+    with django_db_blocker.unblock():
+        try:
+            teardown_databases(db_cfg, verbosity=request.config.option.verbose)
+        except Exception:
+            pass
+
+    if _container_manager is not None:
+        _restore_settings()
+        print("Stopping test containers...")
+        _container_manager.stop_containers()
+        _container_manager = None
 
 
 @pytest.fixture(scope="session")

--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -1,6 +1,8 @@
+from collections.abc import Generator
 from typing import Any
 
 import pytest
+from django.conf import settings
 
 from .manager import ContainerManager
 
@@ -8,54 +10,41 @@ _container_manager: ContainerManager | None = None
 _original_settings: dict[str, Any] = {}
 
 
-@pytest.hookimpl(trylast=True)
-def pytest_load_initial_conftests(
-    early_config: pytest.Config,
-    parser: pytest.Parser,
-    args: list[str],
-) -> None:
-    """Start testcontainers early in pytest lifecycle.
+@pytest.fixture(scope="session", autouse=True)
+def django_testcontainers_setup(
+    django_db_setup: Any,
+) -> Generator[ContainerManager, None, None]:
+    """Automatically start and stop testcontainers for the test session.
 
-    This hook runs after pytest-django configures DJANGO_SETTINGS_MODULE
-    (due to trylast=True) but before any fixtures execute, ensuring
-    containers are ready and settings are patched before django_db_setup.
+    This fixture:
+    1. Runs before any tests
+    2. Detects needed containers from Django settings
+    3. Starts the containers
+    4. Updates Django settings with connection info
+    5. Cleans up containers after all tests complete
 
     Args:
-        early_config: The pytest config object
-        parser: The pytest parser
-        args: Command line arguments
+        django_db_setup: pytest-django fixture that sets up databases
+
+    Yields:
+        ContainerManager instance with active containers
     """
     global _container_manager, _original_settings
 
-    from django.conf import settings
-
-    if not settings.configured:
-        return
-
     _container_manager = ContainerManager(settings)
+
     settings_updates = _container_manager.start_containers()
 
-    _apply_settings_updates(settings, settings_updates)
+    _apply_settings_updates(settings_updates)
 
     for provider_name in _container_manager.active_containers.keys():
         print(f"Started {provider_name} container for testing")
 
+    yield _container_manager
 
-def pytest_unconfigure(config: pytest.Config) -> None:
-    """Stop testcontainers when pytest exits.
-
-    Args:
-        config: The pytest config object
-    """
-    global _container_manager, _original_settings
-
-    if _container_manager is not None:
-        from django.conf import settings
-
-        _restore_settings(settings)
-        print("Stopping test containers...")
-        _container_manager.stop_containers()
-        _container_manager = None
+    _restore_settings()
+    print("Stopping test containers...")
+    _container_manager.stop_containers()
 
 
 @pytest.fixture(scope="session")
@@ -68,11 +57,10 @@ def testcontainers_manager() -> ContainerManager | None:
     return _container_manager
 
 
-def _apply_settings_updates(settings: Any, updates: dict[str, Any]) -> None:
+def _apply_settings_updates(updates: dict[str, Any]) -> None:
     """Apply settings updates and save originals for restoration.
 
     Args:
-        settings: Django settings module
         updates: Dict of settings to update
     """
     global _original_settings
@@ -92,14 +80,13 @@ def _apply_settings_updates(settings: Any, updates: dict[str, Any]) -> None:
             setattr(settings, key, value)
 
 
-def _restore_settings(settings: Any) -> None:
-    """Restore original settings values.
-
-    Args:
-        settings: Django settings module
-    """
+def _restore_settings() -> None:
+    """Restore original settings values."""
     global _original_settings
 
     for key, value in _original_settings.items():
         setattr(settings, key, value)
     _original_settings.clear()
+
+
+pytest_plugins = ["django_testcontainers_plus.pytest_plugin"]

--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -45,7 +45,7 @@ def django_db_setup(
             del connections.__dict__["settings"]
 
         # Reconfigure connections with updated settings
-        connections._settings = connections.configure_settings(settings.DATABASES)
+        connections._settings = connections.configure_settings(settings.DATABASES)  # type: ignore[attr-defined]
 
         # Close all existing connections
         connections.close_all()
@@ -62,7 +62,7 @@ def django_db_setup(
             verbosity=request.config.option.verbose,
             interactive=False,
             keepdb=django_db_keepdb,
-            debug_sql=request.config.option.debug_sql if hasattr(request.config.option, 'debug_sql') else False,
+            debug_sql=getattr(request.config.option, "debug_sql", False),
             parallel=0,
             aliases=None,
             serialized_aliases=None,

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,7 +14,7 @@ class TestPytestPlugin:
         """Test applying simple settings updates."""
         updates = {"TEST_SETTING": "test_value"}
 
-        pytest_plugin._apply_settings_updates(django_settings, updates)
+        pytest_plugin._apply_settings_updates(updates)
 
         assert hasattr(django_settings, "TEST_SETTING")
         assert django_settings.TEST_SETTING == "test_value"
@@ -35,7 +35,7 @@ class TestPytestPlugin:
             }
         }
 
-        pytest_plugin._apply_settings_updates(django_settings, updates)
+        pytest_plugin._apply_settings_updates(updates)
 
         assert hasattr(django_settings, "DATABASES")
         assert "test_db" in django_settings.DATABASES
@@ -49,7 +49,7 @@ class TestPytestPlugin:
         updates = {"TEST_ORIGINAL": "updated"}
 
         pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(django_settings, updates)
+        pytest_plugin._apply_settings_updates(updates)
 
         assert pytest_plugin._original_settings["TEST_ORIGINAL"] == "original"
         assert django_settings.TEST_ORIGINAL == "updated"
@@ -69,7 +69,7 @@ class TestPytestPlugin:
         django_settings.TEST_RESTORE = "updated_value"
         django_settings.TEST_NEW = "new_value"
 
-        pytest_plugin._restore_settings(django_settings)
+        pytest_plugin._restore_settings()
 
         assert django_settings.TEST_RESTORE == "original_value"
         assert pytest_plugin._original_settings == {}
@@ -78,7 +78,7 @@ class TestPytestPlugin:
         """Test restoring when no original settings exist."""
         pytest_plugin._original_settings.clear()
 
-        pytest_plugin._restore_settings(django_settings)
+        pytest_plugin._restore_settings()
 
         assert pytest_plugin._original_settings == {}
 
@@ -105,7 +105,7 @@ class TestPytestPlugin:
         updates = {"NON_DICT_SETTING": {"key": "value"}}
 
         pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(django_settings, updates)
+        pytest_plugin._apply_settings_updates(updates)
 
         assert django_settings.NON_DICT_SETTING == {"key": "value"}
         assert pytest_plugin._original_settings["NON_DICT_SETTING"] == "string_value"
@@ -119,7 +119,7 @@ class TestPytestPlugin:
         }
 
         pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(django_settings, updates)
+        pytest_plugin._apply_settings_updates(updates)
 
         assert django_settings.SETTING_ONE == "value_one"
         assert django_settings.SETTING_TWO == "value_two"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,7 +14,7 @@ class TestPytestPlugin:
         """Test applying simple settings updates."""
         updates = {"TEST_SETTING": "test_value"}
 
-        pytest_plugin._apply_settings_updates(updates)
+        pytest_plugin._apply_settings_updates(django_settings, updates)
 
         assert hasattr(django_settings, "TEST_SETTING")
         assert django_settings.TEST_SETTING == "test_value"
@@ -35,7 +35,7 @@ class TestPytestPlugin:
             }
         }
 
-        pytest_plugin._apply_settings_updates(updates)
+        pytest_plugin._apply_settings_updates(django_settings, updates)
 
         assert hasattr(django_settings, "DATABASES")
         assert "test_db" in django_settings.DATABASES
@@ -49,7 +49,7 @@ class TestPytestPlugin:
         updates = {"TEST_ORIGINAL": "updated"}
 
         pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(updates)
+        pytest_plugin._apply_settings_updates(django_settings, updates)
 
         assert pytest_plugin._original_settings["TEST_ORIGINAL"] == "original"
         assert django_settings.TEST_ORIGINAL == "updated"
@@ -69,7 +69,7 @@ class TestPytestPlugin:
         django_settings.TEST_RESTORE = "updated_value"
         django_settings.TEST_NEW = "new_value"
 
-        pytest_plugin._restore_settings()
+        pytest_plugin._restore_settings(django_settings)
 
         assert django_settings.TEST_RESTORE == "original_value"
         assert pytest_plugin._original_settings == {}
@@ -78,7 +78,7 @@ class TestPytestPlugin:
         """Test restoring when no original settings exist."""
         pytest_plugin._original_settings.clear()
 
-        pytest_plugin._restore_settings()
+        pytest_plugin._restore_settings(django_settings)
 
         assert pytest_plugin._original_settings == {}
 
@@ -105,7 +105,7 @@ class TestPytestPlugin:
         updates = {"NON_DICT_SETTING": {"key": "value"}}
 
         pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(updates)
+        pytest_plugin._apply_settings_updates(django_settings, updates)
 
         assert django_settings.NON_DICT_SETTING == {"key": "value"}
         assert pytest_plugin._original_settings["NON_DICT_SETTING"] == "string_value"
@@ -119,7 +119,7 @@ class TestPytestPlugin:
         }
 
         pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(updates)
+        pytest_plugin._apply_settings_updates(django_settings, updates)
 
         assert django_settings.SETTING_ONE == "value_one"
         assert django_settings.SETTING_TWO == "value_two"


### PR DESCRIPTION
## Summary

Closes #2

The previous implementation used a fixture that depended on `django_db_setup`, which caused containers to start **after** pytest-django had already configured database connections with the original settings. This resulted in connection timeouts because Django's `ConnectionHandler` caches database settings.

## Changes

- Override `django_db_setup` fixture instead of depending on it
- Start testcontainers before any database setup occurs
- Clear Django's cached connection settings (`connections.__dict__["settings"]`)
- Reconfigure connections with `connections.configure_settings()`
- Explicitly recreate database connections with `connections.create_connection()`
- Run pytest-django's database setup logic with the updated settings

## Technical Details

This fix is based on the workaround discussed in [pytest-django#643](https://github.com/pytest-dev/pytest-django/issues/643). The core issue is that Django's `ConnectionHandler` caches database settings when `django.setup()` is called. Simply modifying `settings.DATABASES` after that point has no effect on actual connections.

The solution clears the cached settings and forces Django to recreate connections with the new container database settings before `setup_databases()` is called.

## Test Plan

- [x] All existing tests pass (50/50)
- [x] Tested with a Django project using pytest-django
- [x] Verified testcontainers start and database connects successfully