### PR TITLE
 S3/MinIO Container Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,15 @@ mysql = [
 redis = [
     "redis>=5.0.0",
 ]
+minio = [
+    "minio>=7.0.0",
+    "boto3>=1.26.0",
+]
 all = [
     "mysql-connector-python>=8.0.0",
     "redis>=5.0.0",
+    "minio>=7.0.0",
+    "boto3>=1.26.0",
 ]
 
 [project.urls]

--- a/src/django_testcontainers_plus/providers/__init__.py
+++ b/src/django_testcontainers_plus/providers/__init__.py
@@ -29,3 +29,11 @@ try:
     __all__.append("RedisProvider")
 except ImportError as e:
     UNAVAILABLE_PROVIDERS["redis"] = ("redis", e)
+
+try:
+    from .minio import MinioProvider
+
+    PROVIDER_REGISTRY.append(MinioProvider())
+    __all__.append("MinioProvider")
+except ImportError as e:
+    UNAVAILABLE_PROVIDERS["minio"] = ("minio", e)

--- a/src/django_testcontainers_plus/providers/minio.py
+++ b/src/django_testcontainers_plus/providers/minio.py
@@ -42,7 +42,7 @@ class MinioProvider(ContainerProvider):
     def name(self) -> str:
         return "minio"
 
-    def can_auto_detect(self, settings: Any) -> bool:
+    def can_auto_detect(self, settings: Any, context: dict[str, Any] | None = None) -> bool:
         """Detect S3/MinIO usage from Django settings."""
         # Check DEFAULT_FILE_STORAGE
         default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "")

--- a/src/django_testcontainers_plus/providers/minio.py
+++ b/src/django_testcontainers_plus/providers/minio.py
@@ -1,0 +1,172 @@
+"""MinIO (S3-compatible) container provider."""
+
+from typing import Any
+
+from testcontainers.core.generic import DockerContainer
+from testcontainers.minio import MinioContainer
+
+from .base import ContainerProvider
+
+
+class MinioProvider(ContainerProvider):
+    """Provider for MinIO (S3-compatible) containers.
+
+    MinIO provides S3-compatible object storage for testing file uploads,
+    static files, and media storage without requiring AWS credentials.
+
+    Auto-detects from:
+    - DEFAULT_FILE_STORAGE containing 's3' or 'minio'
+    - STATICFILES_STORAGE containing 's3' or 'minio'
+    - STORAGES dict (Django 4.2+) with S3 backends
+    - AWS_STORAGE_BUCKET_NAME being set
+
+    Configuration options:
+    - image: Docker image (default: 'minio/minio:latest')
+    - access_key: S3 access key (default: 'minioadmin')
+    - secret_key: S3 secret key (default: 'minioadmin')
+    - bucket_name: Default bucket name (default: 'test-bucket')
+    - region: AWS region name (default: 'us-east-1')
+
+    Example:
+        TESTCONTAINERS = {
+            'minio': {
+                'image': 'minio/minio:latest',
+                'access_key': 'test_key',
+                'secret_key': 'test_secret',
+                'bucket_name': 'my-test-bucket',
+            }
+        }
+    """
+
+    @property
+    def name(self) -> str:
+        return "minio"
+
+    def can_auto_detect(self, settings: Any) -> bool:
+        """Detect S3/MinIO usage from Django settings."""
+        # Check DEFAULT_FILE_STORAGE
+        default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "")
+        if self._is_s3_storage(default_storage):
+            return True
+
+        # Check STATICFILES_STORAGE
+        static_storage = getattr(settings, "STATICFILES_STORAGE", "")
+        if self._is_s3_storage(static_storage):
+            return True
+
+        # Check STORAGES dict (Django 4.2+)
+        storages = getattr(settings, "STORAGES", {})
+        for storage_config in storages.values():
+            if isinstance(storage_config, dict):
+                backend = storage_config.get("BACKEND", "")
+                if self._is_s3_storage(backend):
+                    return True
+
+        # Check for AWS S3 configuration
+        if getattr(settings, "AWS_STORAGE_BUCKET_NAME", None):
+            return True
+
+        return False
+
+    def _is_s3_storage(self, storage_class: str) -> bool:
+        """Check if storage class is S3-related."""
+        storage_lower = storage_class.lower()
+        return any(
+            pattern in storage_lower
+            for pattern in [
+                "s3boto3",
+                "s3boto",
+                "minio",
+                "s3storage",
+            ]
+        )
+
+    def get_container(self, config: dict[str, Any]) -> DockerContainer:
+        """Create MinIO container with configuration."""
+        image = config.get("image", "minio/minio:latest")
+        access_key = config.get("access_key", "minioadmin")
+        secret_key = config.get("secret_key", "minioadmin")
+
+        container = MinioContainer(
+            image=image,
+            access_key=access_key,
+            secret_key=secret_key,
+        )
+
+        # Add custom environment variables
+        env = config.get("environment", {})
+        for key, value in env.items():
+            container = container.with_env(key, value)
+
+        return container
+
+    def update_settings(
+        self, container: DockerContainer, settings: Any, config: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Update AWS/S3 settings with container connection info."""
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(9000)
+        endpoint_url = f"http://{host}:{port}"
+
+        access_key = config.get("access_key", "minioadmin")
+        secret_key = config.get("secret_key", "minioadmin")
+        bucket_name = config.get("bucket_name", "test-bucket")
+        region = config.get("region", "us-east-1")
+
+        # Allow custom settings override
+        if "update_settings" in config:
+            custom_settings = config["update_settings"]
+            if isinstance(custom_settings, dict):
+                return custom_settings
+
+        updates: dict[str, Any] = {
+            # Core AWS credentials
+            "AWS_ACCESS_KEY_ID": access_key,
+            "AWS_SECRET_ACCESS_KEY": secret_key,
+            "AWS_S3_ENDPOINT_URL": endpoint_url,
+            "AWS_STORAGE_BUCKET_NAME": bucket_name,
+            "AWS_S3_REGION_NAME": region,
+            # Common django-storages settings
+            "AWS_S3_CUSTOM_DOMAIN": None,  # Disable CDN for testing
+            "AWS_S3_SECURE_URLS": False,  # Use HTTP for local testing
+            "AWS_QUERYSTRING_AUTH": False,  # Simpler URLs for testing
+            "AWS_DEFAULT_ACL": None,  # Use bucket default
+            # MinIO-specific settings
+            "AWS_S3_SIGNATURE_VERSION": "s3v4",
+            "AWS_S3_ADDRESSING_STYLE": "path",  # Required for MinIO
+        }
+
+        # Update STORAGES dict if present (Django 4.2+)
+        storages = getattr(settings, "STORAGES", {})
+        if storages:
+            storages_updates: dict[str, Any] = {}
+            for storage_name, storage_config in storages.items():
+                if isinstance(storage_config, dict):
+                    backend = storage_config.get("BACKEND", "")
+                    if self._is_s3_storage(backend):
+                        existing_options = storage_config.get("OPTIONS", {})
+                        storages_updates[storage_name] = {
+                            **storage_config,
+                            "OPTIONS": {
+                                **existing_options,
+                                "endpoint_url": endpoint_url,
+                                "access_key": access_key,
+                                "secret_key": secret_key,
+                                "bucket_name": bucket_name,
+                                "region_name": region,
+                            },
+                        }
+            if storages_updates:
+                updates["STORAGES"] = storages_updates
+
+        return updates
+
+    def get_default_config(self) -> dict[str, Any]:
+        """Get default configuration for MinIO provider."""
+        return {
+            "image": "minio/minio:latest",
+            "access_key": "minioadmin",
+            "secret_key": "minioadmin",
+            "bucket_name": "test-bucket",
+            "region": "us-east-1",
+        }

--- a/src/django_testcontainers_plus/providers/minio.py
+++ b/src/django_testcontainers_plus/providers/minio.py
@@ -43,27 +43,45 @@ class MinioProvider(ContainerProvider):
         return "minio"
 
     def can_auto_detect(self, settings: Any, context: dict[str, Any] | None = None) -> bool:
-        """Detect S3/MinIO usage from Django settings."""
-        # Check DEFAULT_FILE_STORAGE
-        default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "")
+        """Detect S3/MinIO usage from Django settings.
+
+        Context keys (override settings if present):
+            original_default_file_storage, original_staticfiles_storage,
+            original_storages, original_aws_storage_bucket_name
+        """
+        # DEFAULT_FILE_STORAGE
+        if context and context.get("original_default_file_storage") is not None:
+            default_storage = context["original_default_file_storage"]
+        else:
+            default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "")
         if self._is_s3_storage(default_storage):
             return True
 
-        # Check STATICFILES_STORAGE
-        static_storage = getattr(settings, "STATICFILES_STORAGE", "")
+        # STATICFILES_STORAGE
+        if context and context.get("original_staticfiles_storage") is not None:
+            static_storage = context["original_staticfiles_storage"]
+        else:
+            static_storage = getattr(settings, "STATICFILES_STORAGE", "")
         if self._is_s3_storage(static_storage):
             return True
 
-        # Check STORAGES dict (Django 4.2+)
-        storages = getattr(settings, "STORAGES", {})
+        # STORAGES dict (Django 4.2+)
+        if context and context.get("original_storages") is not None:
+            storages = context["original_storages"]
+        else:
+            storages = getattr(settings, "STORAGES", {})
         for storage_config in storages.values():
             if isinstance(storage_config, dict):
                 backend = storage_config.get("BACKEND", "")
                 if self._is_s3_storage(backend):
                     return True
 
-        # Check for AWS S3 configuration
-        if getattr(settings, "AWS_STORAGE_BUCKET_NAME", None):
+        # AWS_STORAGE_BUCKET_NAME
+        if context and context.get("original_aws_storage_bucket_name") is not None:
+            aws_bucket = context["original_aws_storage_bucket_name"]
+        else:
+            aws_bucket = getattr(settings, "AWS_STORAGE_BUCKET_NAME", None)
+        if aws_bucket:
             return True
 
         return False

--- a/tests/test_minio_provider.py
+++ b/tests/test_minio_provider.py
@@ -133,6 +133,96 @@ class TestMinioProviderAutoDetect:
         provider = MinioProvider()
         assert provider.can_auto_detect(settings) is False
 
+    def test_can_auto_detect_uses_context_default_file_storage(self) -> None:
+        """Should use original_default_file_storage from context over settings."""
+        settings = Mock()
+        # Settings have been modified (e.g., by test framework)
+        settings.DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        # Context preserves the original S3 value
+        context = {
+            "original_default_file_storage": "storages.backends.s3boto3.S3Boto3Storage",
+        }
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings, context) is True
+
+    def test_can_auto_detect_uses_context_staticfiles_storage(self) -> None:
+        """Should use original_staticfiles_storage from context over settings."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        context = {
+            "original_staticfiles_storage": "storages.backends.s3boto3.S3StaticStorage",
+        }
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings, context) is True
+
+    def test_can_auto_detect_uses_context_storages_dict(self) -> None:
+        """Should use original_storages from context over settings."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}  # Modified by test framework
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        context = {
+            "original_storages": {
+                "default": {
+                    "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+                }
+            },
+        }
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings, context) is True
+
+    def test_can_auto_detect_uses_context_aws_bucket_name(self) -> None:
+        """Should use original_aws_storage_bucket_name from context over settings."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None  # Cleared by test framework
+
+        context = {
+            "original_aws_storage_bucket_name": "my-production-bucket",
+        }
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings, context) is True
+
+    def test_can_auto_detect_empty_context_falls_back_to_settings(self) -> None:
+        """Should fall back to settings when context is empty."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings, context={}) is True
+
+    def test_can_auto_detect_context_with_none_value_falls_back(self) -> None:
+        """Should fall back to settings when context value is None."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        context = {"original_default_file_storage": None}
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings, context) is True
+
 
 class TestMinioProviderContainer:
     """Tests for MinIO container creation."""

--- a/tests/test_minio_provider.py
+++ b/tests/test_minio_provider.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import Mock, patch
 
-import pytest
-
 from django_testcontainers_plus.providers.minio import MinioProvider
 
 

--- a/tests/test_minio_provider.py
+++ b/tests/test_minio_provider.py
@@ -1,0 +1,390 @@
+"""Tests for MinIO provider."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from django_testcontainers_plus.providers.minio import MinioProvider
+
+
+class TestMinioProviderName:
+    """Tests for MinIO provider name."""
+
+    def test_name_is_minio(self) -> None:
+        """Provider name should be 'minio'."""
+        provider = MinioProvider()
+        assert provider.name == "minio"
+
+
+class TestMinioProviderAutoDetect:
+    """Tests for MinIO auto-detection."""
+
+    def test_can_auto_detect_s3boto3_storage(self) -> None:
+        """Should detect django-storages S3Boto3Storage."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_s3boto_storage(self) -> None:
+        """Should detect older S3BotoStorage."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = "storages.backends.s3boto.S3BotoStorage"
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_staticfiles_storage(self) -> None:
+        """Should detect S3 staticfiles storage."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = "storages.backends.s3boto3.S3StaticStorage"
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_storages_dict_default(self) -> None:
+        """Should detect S3 in STORAGES dict default backend."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {
+            "default": {
+                "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+            }
+        }
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_storages_dict_staticfiles(self) -> None:
+        """Should detect S3 in STORAGES dict staticfiles backend."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {
+            "staticfiles": {
+                "BACKEND": "storages.backends.s3boto3.S3StaticStorage",
+            }
+        }
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_aws_bucket_name(self) -> None:
+        """Should detect when AWS_STORAGE_BUCKET_NAME is set."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = "my-bucket"
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_minio_storage(self) -> None:
+        """Should detect custom MinIO storage backend."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = "myapp.storage.MinioStorage"
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is True
+
+    def test_no_auto_detect_filesystem_storage(self) -> None:
+        """Should not detect FileSystemStorage."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+        settings.STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is False
+
+    def test_no_auto_detect_empty_settings(self) -> None:
+        """Should not detect when no storage settings present."""
+        settings = Mock()
+        settings.DEFAULT_FILE_STORAGE = ""
+        settings.STATICFILES_STORAGE = ""
+        settings.STORAGES = {}
+        settings.AWS_STORAGE_BUCKET_NAME = None
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is False
+
+    def test_no_auto_detect_no_attributes(self) -> None:
+        """Should not detect when settings attributes don't exist."""
+        settings = Mock(spec=[])  # No attributes
+
+        provider = MinioProvider()
+        assert provider.can_auto_detect(settings) is False
+
+
+class TestMinioProviderContainer:
+    """Tests for MinIO container creation."""
+
+    def test_get_container_defaults(self) -> None:
+        """Should create container with default config."""
+        provider = MinioProvider()
+        config = provider.get_default_config()
+
+        with patch(
+            "django_testcontainers_plus.providers.minio.MinioContainer"
+        ) as mock_container:
+            mock_instance = Mock()
+            mock_container.return_value = mock_instance
+
+            result = provider.get_container(config)
+
+            mock_container.assert_called_once_with(
+                image="minio/minio:latest",
+                access_key="minioadmin",
+                secret_key="minioadmin",
+            )
+            assert result == mock_instance
+
+    def test_get_container_custom_image(self) -> None:
+        """Should create container with custom image."""
+        provider = MinioProvider()
+        config = {
+            "image": "minio/minio:RELEASE.2024-01-01",
+            "access_key": "minioadmin",
+            "secret_key": "minioadmin",
+        }
+
+        with patch(
+            "django_testcontainers_plus.providers.minio.MinioContainer"
+        ) as mock_container:
+            mock_instance = Mock()
+            mock_container.return_value = mock_instance
+
+            provider.get_container(config)
+
+            mock_container.assert_called_once_with(
+                image="minio/minio:RELEASE.2024-01-01",
+                access_key="minioadmin",
+                secret_key="minioadmin",
+            )
+
+    def test_get_container_custom_credentials(self) -> None:
+        """Should create container with custom credentials."""
+        provider = MinioProvider()
+        config = {
+            "image": "minio/minio:latest",
+            "access_key": "custom_access_key",
+            "secret_key": "custom_secret_key",
+        }
+
+        with patch(
+            "django_testcontainers_plus.providers.minio.MinioContainer"
+        ) as mock_container:
+            mock_instance = Mock()
+            mock_container.return_value = mock_instance
+
+            provider.get_container(config)
+
+            mock_container.assert_called_once_with(
+                image="minio/minio:latest",
+                access_key="custom_access_key",
+                secret_key="custom_secret_key",
+            )
+
+    def test_get_container_with_environment(self) -> None:
+        """Should add environment variables to container."""
+        provider = MinioProvider()
+        config = {
+            "image": "minio/minio:latest",
+            "access_key": "minioadmin",
+            "secret_key": "minioadmin",
+            "environment": {
+                "MINIO_BROWSER": "off",
+                "MINIO_CONSOLE_ADDRESS": ":9001",
+            },
+        }
+
+        with patch(
+            "django_testcontainers_plus.providers.minio.MinioContainer"
+        ) as mock_container:
+            mock_instance = Mock()
+            mock_instance.with_env.return_value = mock_instance
+            mock_container.return_value = mock_instance
+
+            provider.get_container(config)
+
+            assert mock_instance.with_env.call_count == 2
+
+
+class TestMinioProviderSettings:
+    """Tests for MinIO settings updates."""
+
+    def test_update_settings_basic(self) -> None:
+        """Should update AWS settings with container info."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "localhost"
+        container.get_exposed_port.return_value = "9000"
+
+        settings = Mock()
+        settings.STORAGES = {}
+
+        config = provider.get_default_config()
+        updates = provider.update_settings(container, settings, config)
+
+        assert updates["AWS_ACCESS_KEY_ID"] == "minioadmin"
+        assert updates["AWS_SECRET_ACCESS_KEY"] == "minioadmin"
+        assert updates["AWS_S3_ENDPOINT_URL"] == "http://localhost:9000"
+        assert updates["AWS_STORAGE_BUCKET_NAME"] == "test-bucket"
+        assert updates["AWS_S3_REGION_NAME"] == "us-east-1"
+        assert updates["AWS_S3_SIGNATURE_VERSION"] == "s3v4"
+        assert updates["AWS_S3_ADDRESSING_STYLE"] == "path"
+
+    def test_update_settings_custom_bucket(self) -> None:
+        """Should use custom bucket name."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "localhost"
+        container.get_exposed_port.return_value = "9000"
+
+        settings = Mock()
+        settings.STORAGES = {}
+
+        config = {**provider.get_default_config(), "bucket_name": "custom-bucket"}
+        updates = provider.update_settings(container, settings, config)
+
+        assert updates["AWS_STORAGE_BUCKET_NAME"] == "custom-bucket"
+
+    def test_update_settings_custom_region(self) -> None:
+        """Should use custom region."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "localhost"
+        container.get_exposed_port.return_value = "9000"
+
+        settings = Mock()
+        settings.STORAGES = {}
+
+        config = {**provider.get_default_config(), "region": "eu-west-1"}
+        updates = provider.update_settings(container, settings, config)
+
+        assert updates["AWS_S3_REGION_NAME"] == "eu-west-1"
+
+    def test_update_settings_custom_credentials(self) -> None:
+        """Should use custom credentials in settings."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "localhost"
+        container.get_exposed_port.return_value = "9000"
+
+        settings = Mock()
+        settings.STORAGES = {}
+
+        config = {
+            **provider.get_default_config(),
+            "access_key": "custom_key",
+            "secret_key": "custom_secret",
+        }
+        updates = provider.update_settings(container, settings, config)
+
+        assert updates["AWS_ACCESS_KEY_ID"] == "custom_key"
+        assert updates["AWS_SECRET_ACCESS_KEY"] == "custom_secret"
+
+    def test_update_settings_storages_dict(self) -> None:
+        """Should update STORAGES dict with S3 backends."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "localhost"
+        container.get_exposed_port.return_value = "9000"
+
+        settings = Mock()
+        settings.STORAGES = {
+            "default": {
+                "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+                "OPTIONS": {"file_overwrite": False},
+            },
+            "staticfiles": {
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+            },
+        }
+
+        config = provider.get_default_config()
+        updates = provider.update_settings(container, settings, config)
+
+        # Should update only S3 storage
+        assert "STORAGES" in updates
+        assert "default" in updates["STORAGES"]
+        assert "staticfiles" not in updates["STORAGES"]
+
+        # Should preserve existing options and add new ones
+        default_options = updates["STORAGES"]["default"]["OPTIONS"]
+        assert default_options["file_overwrite"] is False
+        assert default_options["endpoint_url"] == "http://localhost:9000"
+        assert default_options["access_key"] == "minioadmin"
+        assert default_options["bucket_name"] == "test-bucket"
+
+    def test_update_settings_custom_override(self) -> None:
+        """Should use custom update_settings when provided."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "localhost"
+        container.get_exposed_port.return_value = "9000"
+
+        settings = Mock()
+        settings.STORAGES = {}
+
+        custom_settings = {"CUSTOM_SETTING": "custom_value"}
+        config = {**provider.get_default_config(), "update_settings": custom_settings}
+        updates = provider.update_settings(container, settings, config)
+
+        assert updates == custom_settings
+
+    def test_update_settings_different_port(self) -> None:
+        """Should use actual exposed port."""
+        provider = MinioProvider()
+        container = Mock()
+        container.get_container_host_ip.return_value = "192.168.1.100"
+        container.get_exposed_port.return_value = "32768"
+
+        settings = Mock()
+        settings.STORAGES = {}
+
+        config = provider.get_default_config()
+        updates = provider.update_settings(container, settings, config)
+
+        assert updates["AWS_S3_ENDPOINT_URL"] == "http://192.168.1.100:32768"
+
+
+class TestMinioProviderDefaultConfig:
+    """Tests for MinIO default configuration."""
+
+    def test_default_config_values(self) -> None:
+        """Should have expected default values."""
+        provider = MinioProvider()
+        config = provider.get_default_config()
+
+        assert config["image"] == "minio/minio:latest"
+        assert config["access_key"] == "minioadmin"
+        assert config["secret_key"] == "minioadmin"
+        assert config["bucket_name"] == "test-bucket"
+        assert config["region"] == "us-east-1"
+
+    def test_default_config_keys(self) -> None:
+        """Should have all expected keys."""
+        provider = MinioProvider()
+        config = provider.get_default_config()
+
+        expected_keys = {"image", "access_key", "secret_key", "bucket_name", "region"}
+        assert set(config.keys()) == expected_keys


### PR DESCRIPTION
## Description

Addresses #6

This update adds a new `MinioProvider` that enables S3-compatible object storage testing using MinIO containers. It allows Django projects to test file uploads, static files, and media storage without requiring real AWS credentials.

### Key Features

- **Auto-detection**: Automatically detects S3/MinIO usage from Django settings (`DEFAULT_FILE_STORAGE`, `STATICFILES_STORAGE`, `STORAGES` dict, or `AWS_STORAGE_BUCKET_NAME`)
- **Django 4.2+ Support**: Full compatibility with the new `STORAGES` configuration format
- **Zero AWS Dependencies**: Test S3 storage backends locally without AWS credentials
- **Configurable**: Custom access keys, secret keys, bucket names, and regions

### Configuration Example

```python
TESTCONTAINERS = {
    'minio': {
        'image': 'minio/minio:latest',
        'access_key': 'test_key',
        'secret_key': 'test_secret',
        'bucket_name': 'my-test-bucket',
        'region': 'us-east-1',
    }
}
```