### PR TITLE
fix(runner): add database connection recreation after settings update

### DIFF
--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -3,9 +3,9 @@ from typing import Any
 
 import pytest
 from django.conf import settings
-from django.db import connections
 
 from .manager import ContainerManager
+from .utils import apply_settings_updates, recreate_database_connections, restore_settings
 
 _container_manager: ContainerManager | None = None
 _original_settings: dict[str, Any] = {}
@@ -37,22 +37,8 @@ def django_db_setup(
     settings_updates = _container_manager.start_containers()
 
     if settings_updates:
-        # Apply settings updates
-        _apply_settings_updates(settings_updates)
-
-        # Clear Django's cached connection settings
-        if "settings" in connections.__dict__:
-            del connections.__dict__["settings"]
-
-        # Reconfigure connections with updated settings
-        connections._settings = connections.configure_settings(settings.DATABASES)  # type: ignore[attr-defined]
-
-        # Close all existing connections
-        connections.close_all()
-
-        # Explicitly recreate connections with new settings
-        for alias in settings.DATABASES:
-            connections[alias] = connections.create_connection(alias)
+        apply_settings_updates(settings_updates, _original_settings)
+        recreate_database_connections()
 
     # Now run pytest-django's database setup logic
     from django.test.utils import setup_databases, teardown_databases
@@ -79,7 +65,7 @@ def django_db_setup(
             pass
 
     if _container_manager is not None:
-        _restore_settings()
+        restore_settings(_original_settings)
         print("Stopping test containers...")
         _container_manager.stop_containers()
         _container_manager = None
@@ -93,38 +79,6 @@ def testcontainers_manager() -> ContainerManager | None:
         ContainerManager instance with active containers
     """
     return _container_manager
-
-
-def _apply_settings_updates(updates: dict[str, Any]) -> None:
-    """Apply settings updates and save originals for restoration.
-
-    Args:
-        updates: Dict of settings to update
-    """
-    global _original_settings
-
-    for key, value in updates.items():
-        if key not in _original_settings:
-            _original_settings[key] = getattr(settings, key, None)
-
-        if isinstance(value, dict) and hasattr(settings, key):
-            original = getattr(settings, key, {})
-            if isinstance(original, dict):
-                merged = {**original, **value}
-                setattr(settings, key, merged)
-            else:
-                setattr(settings, key, value)
-        else:
-            setattr(settings, key, value)
-
-
-def _restore_settings() -> None:
-    """Restore original settings values."""
-    global _original_settings
-
-    for key, value in _original_settings.items():
-        setattr(settings, key, value)
-    _original_settings.clear()
 
 
 pytest_plugins = ["django_testcontainers_plus.pytest_plugin"]

--- a/src/django_testcontainers_plus/runner.py
+++ b/src/django_testcontainers_plus/runner.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.test.runner import DiscoverRunner
 
 from .manager import ContainerManager
+from .utils import apply_settings_updates, recreate_database_connections, restore_settings
 
 
 class TestcontainersRunner(DiscoverRunner):
@@ -41,7 +42,9 @@ class TestcontainersRunner(DiscoverRunner):
 
         settings_updates = self.container_manager.start_containers()
 
-        self._apply_settings_updates(settings_updates)
+        if settings_updates:
+            apply_settings_updates(settings_updates, self.original_settings)
+            recreate_database_connections()
 
         if self.verbosity >= 1:
             for provider_name in self.container_manager.active_containers.keys():
@@ -49,7 +52,7 @@ class TestcontainersRunner(DiscoverRunner):
 
     def teardown_test_environment(self, **kwargs: Any) -> None:
         """Tear down test environment and stop containers."""
-        self._restore_settings()
+        restore_settings(self.original_settings)
 
         if self.container_manager:
             if self.verbosity >= 1:
@@ -57,29 +60,3 @@ class TestcontainersRunner(DiscoverRunner):
             self.container_manager.stop_containers()
 
         super().teardown_test_environment(**kwargs)
-
-    def _apply_settings_updates(self, updates: dict[str, Any]) -> None:
-        """Apply settings updates and save originals for restoration.
-
-        Args:
-            updates: Dict of settings to update
-        """
-        for key, value in updates.items():
-            if key not in self.original_settings:
-                self.original_settings[key] = getattr(settings, key, None)
-
-            if isinstance(value, dict) and hasattr(settings, key):
-                original = getattr(settings, key, {})
-                if isinstance(original, dict):
-                    merged = {**original, **value}
-                    setattr(settings, key, merged)
-                else:
-                    setattr(settings, key, value)
-            else:
-                setattr(settings, key, value)
-
-    def _restore_settings(self) -> None:
-        """Restore original settings values."""
-        for key, value in self.original_settings.items():
-            setattr(settings, key, value)
-        self.original_settings.clear()

--- a/src/django_testcontainers_plus/utils.py
+++ b/src/django_testcontainers_plus/utils.py
@@ -1,0 +1,62 @@
+"""Utility functions shared between runner and pytest plugin."""
+
+from typing import Any
+
+from django.conf import settings
+from django.db import connections
+
+
+def apply_settings_updates(
+    updates: dict[str, Any], original_settings: dict[str, Any]
+) -> None:
+    """Apply settings updates and save originals for restoration.
+
+    Args:
+        updates: Dict of settings to update
+        original_settings: Dict to store original values for later restoration
+    """
+    for key, value in updates.items():
+        if key not in original_settings:
+            original_settings[key] = getattr(settings, key, None)
+
+        if isinstance(value, dict) and hasattr(settings, key):
+            original = getattr(settings, key, {})
+            if isinstance(original, dict):
+                merged = {**original, **value}
+                setattr(settings, key, merged)
+            else:
+                setattr(settings, key, value)
+        else:
+            setattr(settings, key, value)
+
+
+def restore_settings(original_settings: dict[str, Any]) -> None:
+    """Restore original settings values.
+
+    Args:
+        original_settings: Dict of original values to restore
+    """
+    for key, value in original_settings.items():
+        setattr(settings, key, value)
+    original_settings.clear()
+
+
+def recreate_database_connections() -> None:
+    """Recreate Django database connections with current settings.
+
+    This is needed after updating DATABASES settings to ensure Django
+    uses the new connection parameters instead of cached ones.
+    """
+    # Clear Django's cached connection settings
+    if "settings" in connections.__dict__:
+        del connections.__dict__["settings"]
+
+    # Reconfigure connections with updated settings
+    connections._settings = connections.configure_settings(settings.DATABASES)  # type: ignore[attr-defined]
+
+    # Close all existing connections
+    connections.close_all()
+
+    # Explicitly recreate connections with new settings
+    for alias in settings.DATABASES:
+        connections[alias] = connections.create_connection(alias)

--- a/src/django_testcontainers_plus/utils.py
+++ b/src/django_testcontainers_plus/utils.py
@@ -6,9 +6,7 @@ from django.conf import settings
 from django.db import connections
 
 
-def apply_settings_updates(
-    updates: dict[str, Any], original_settings: dict[str, Any]
-) -> None:
+def apply_settings_updates(updates: dict[str, Any], original_settings: dict[str, Any]) -> None:
     """Apply settings updates and save originals for restoration.
 
     Args:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,10 +1,11 @@
-"""Tests for pytest plugin."""
+"""Tests for pytest plugin and utils."""
 
 from unittest.mock import Mock
 
 from django.conf import settings as django_settings
 
 from django_testcontainers_plus import pytest_plugin
+from django_testcontainers_plus.utils import apply_settings_updates, restore_settings
 
 
 class TestPytestPlugin:
@@ -13,18 +14,17 @@ class TestPytestPlugin:
     def test_apply_settings_updates_simple(self):
         """Test applying simple settings updates."""
         updates = {"TEST_SETTING": "test_value"}
+        original_settings: dict = {}
 
-        pytest_plugin._apply_settings_updates(updates)
+        apply_settings_updates(updates, original_settings)
 
         assert hasattr(django_settings, "TEST_SETTING")
         assert django_settings.TEST_SETTING == "test_value"
-        assert "TEST_SETTING" in pytest_plugin._original_settings
+        assert "TEST_SETTING" in original_settings
 
     def test_apply_settings_updates_dict_merge(self):
         """Test applying dict settings with merge."""
-        original_databases = getattr(django_settings, "DATABASES", {})
-        if not isinstance(original_databases, dict):
-            original_databases = {}
+        original_settings: dict = {}
 
         updates = {
             "DATABASES": {
@@ -35,7 +35,7 @@ class TestPytestPlugin:
             }
         }
 
-        pytest_plugin._apply_settings_updates(updates)
+        apply_settings_updates(updates, original_settings)
 
         assert hasattr(django_settings, "DATABASES")
         assert "test_db" in django_settings.DATABASES
@@ -48,10 +48,10 @@ class TestPytestPlugin:
         django_settings.TEST_ORIGINAL = "original"
         updates = {"TEST_ORIGINAL": "updated"}
 
-        pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(updates)
+        original_settings: dict = {}
+        apply_settings_updates(updates, original_settings)
 
-        assert pytest_plugin._original_settings["TEST_ORIGINAL"] == "original"
+        assert original_settings["TEST_ORIGINAL"] == "original"
         assert django_settings.TEST_ORIGINAL == "updated"
 
         if original_value is not None:
@@ -61,7 +61,7 @@ class TestPytestPlugin:
 
     def test_restore_settings(self):
         """Test restoring original settings."""
-        pytest_plugin._original_settings = {
+        original_settings = {
             "TEST_RESTORE": "original_value",
             "TEST_NEW": None,
         }
@@ -69,18 +69,18 @@ class TestPytestPlugin:
         django_settings.TEST_RESTORE = "updated_value"
         django_settings.TEST_NEW = "new_value"
 
-        pytest_plugin._restore_settings()
+        restore_settings(original_settings)
 
         assert django_settings.TEST_RESTORE == "original_value"
-        assert pytest_plugin._original_settings == {}
+        assert original_settings == {}
 
     def test_restore_settings_empty(self):
         """Test restoring when no original settings exist."""
-        pytest_plugin._original_settings.clear()
+        original_settings: dict = {}
 
-        pytest_plugin._restore_settings()
+        restore_settings(original_settings)
 
-        assert pytest_plugin._original_settings == {}
+        assert original_settings == {}
 
     def test_container_manager_module_state(self):
         """Test that module-level container manager state works."""
@@ -104,11 +104,11 @@ class TestPytestPlugin:
         django_settings.NON_DICT_SETTING = "string_value"
         updates = {"NON_DICT_SETTING": {"key": "value"}}
 
-        pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(updates)
+        original_settings: dict = {}
+        apply_settings_updates(updates, original_settings)
 
         assert django_settings.NON_DICT_SETTING == {"key": "value"}
-        assert pytest_plugin._original_settings["NON_DICT_SETTING"] == "string_value"
+        assert original_settings["NON_DICT_SETTING"] == "string_value"
 
     def test_apply_settings_updates_multiple(self):
         """Test applying multiple settings updates."""
@@ -118,10 +118,10 @@ class TestPytestPlugin:
             "SETTING_THREE": {"nested": "value"},
         }
 
-        pytest_plugin._original_settings.clear()
-        pytest_plugin._apply_settings_updates(updates)
+        original_settings: dict = {}
+        apply_settings_updates(updates, original_settings)
 
         assert django_settings.SETTING_ONE == "value_one"
         assert django_settings.SETTING_TWO == "value_two"
         assert django_settings.SETTING_THREE == {"nested": "value"}
-        assert len(pytest_plugin._original_settings) == 3
+        assert len(original_settings) == 3


### PR DESCRIPTION
## Summary

- Extract shared utility functions into `utils.py` for reuse between runner and pytest plugin
- Add missing `recreate_database_connections()` call to the Django test runner
- Refactor pytest plugin to use the same shared utilities

## Problem

The Django test runner was missing the connection recreation logic that was added to the pytest plugin in #2. After updating `DATABASES` settings with container connection info, Django continued using cached connections, causing the runner to hang during database creation.

## Changes

New `utils.py` module with:
- `apply_settings_updates()`: applies settings and tracks originals
- `restore_settings()`: restores original settings
- `recreate_database_connections()`: clears cached connections and recreates them

Both `runner.py` and `pytest_plugin.py` now use these shared utilities.

## Test plan

- [x] All existing tests pass (50 tests)
- [x] Linting passes
- [x] Type checking passes
- [x] Manual test with Django test runner

Closes #16