### PR TITLE
Add S3-compatible object storage provider (RustFS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main, develop]
 
 jobs:
-  pytest:
-    name: pytest (Python ${{ matrix.python-version }})
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,7 +32,7 @@ jobs:
         run: |
           uv sync --all-extras --dev
 
-      - name: Run pytest tests
+      - name: Run tests
         run: make coverage
 
       - name: Upload coverage to Codecov
@@ -40,54 +40,8 @@ jobs:
         if: matrix.python-version == '3.13'
         with:
           file: ./coverage.xml
-          flags: pytest
-          name: pytest-py${{ matrix.python-version }}
-
-  django-tests:
-    name: Django tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-
-      - name: Install dependencies
-        run: |
-          uv sync --all-extras --dev
-
-      - name: Run Django tests
-        env:
-          DJANGO_SETTINGS_MODULE: tests.settings
-        run: |
-          uv run python -m django test --settings=tests.settings
+          flags: tests
+          name: tests-py${{ matrix.python-version }}
 
   code-quality:
     name: Code Quality
@@ -119,14 +73,13 @@ jobs:
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [pytest, django-tests, code-quality]
+    needs: [tests, code-quality]
     if: always()
 
     steps:
       - name: Check all jobs
         run: |
-          if [[ "${{ needs.pytest.result }}" != "success" ]] || \
-             [[ "${{ needs.django-tests.result }}" != "success" ]] || \
+          if [[ "${{ needs.tests.result }}" != "success" ]] || \
              [[ "${{ needs.code-quality.result }}" != "success" ]]; then
             echo "One or more checks failed"
             exit 1

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "  make format     - Auto-format code with ruff"
 	@echo "  make lint       - Run ruff linting"
 	@echo "  make typecheck  - Run mypy type checking"
-	@echo "  make test       - Run pytest tests"
+	@echo "  make test       - Run all tests (requires Docker)"
 	@echo "  make coverage   - Run tests with coverage report"
 	@echo "  make check      - Run all checks (lint, typecheck, test)"
 	@echo "  make clean      - Remove generated files"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ pip install django-testcontainers-plus[mysql]
 # Redis support
 pip install django-testcontainers-plus[redis]
 
-# Or install both
+# S3 support (RustFS)
+pip install django-testcontainers-plus[s3]
+
+# Or install all
 pip install django-testcontainers-plus[all]
 ```
 
@@ -325,6 +328,9 @@ pip install django-testcontainers-plus[mysql]
 
 # For Redis
 pip install django-testcontainers-plus[redis]
+
+# For S3 (RustFS)
+pip install django-testcontainers-plus[s3]
 
 # Or install everything
 pip install django-testcontainers-plus[all]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Testing Django applications often requires external services like PostgreSQL, Re
 - **Zero Configuration**: Automatically detects your database and service needs from Django settings
 - **Plug and Play**: Install, add to settings, and go - no manual container management
 - **Database Agnostic**: Supports PostgreSQL, MySQL, MariaDB, and more
-- **Beyond Databases**: Redis for caching, MinIO for S3, and other services
+- **Beyond Databases**: Redis for caching, S3-compatible storage, and other services
 - **Dual Compatibility**: Works with both Django's test runner and pytest
 - **Smart Defaults**: Sensible defaults with full customization when needed
 
@@ -103,7 +103,7 @@ pytest
 
 - Redis - Auto-detected from cache/Celery settings
 - Mailhog - Auto-detected from SMTP email backend
-- MinIO - S3-compatible storage (coming soon)
+- S3 (RustFS) - Auto-detected from django-storages S3 backend
 - Elasticsearch - Search (coming soon)
 
 ## Configuration
@@ -399,7 +399,7 @@ uv run mypy src/
 - [x] pytest plugin
 - [x] Mailhog support
 - [ ] MongoDB support
-- [ ] MinIO (S3) support
+- [x] S3-compatible object storage (RustFS)
 - [ ] Elasticsearch support
 - [ ] RabbitMQ support
 - [ ] Container reuse between test runs

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ Testing Django applications often requires real external services like PostgreSQ
 | **MySQL / MariaDB** | `DATABASES` engine | `[mysql]` |
 | **Redis** | `CACHES`, `CELERY_BROKER_URL`, `SESSION_ENGINE` | `[redis]` |
 | MongoDB | Coming soon | - |
-| MinIO (S3) | Coming soon | - |
+| **S3 (RustFS)** | `STORAGES`, `DEFAULT_FILE_STORAGE`, `AWS_STORAGE_BUCKET_NAME` | `[s3]` |
 | Elasticsearch | Coming soon | - |
 
 ## Next Steps

--- a/docs/pages/providers/s3.md
+++ b/docs/pages/providers/s3.md
@@ -1,0 +1,129 @@
+# S3 (Object Storage) Provider
+
+The S3 provider requires the `[s3]` extra to be installed. It uses [RustFS](https://github.com/rustfs/rustfs) by default -- a fully S3-compatible, Apache 2.0 licensed storage server.
+
+!!! note "Why RustFS instead of MinIO?"
+    MinIO's open-source repository was [archived in February 2026](https://www.infoq.com/news/2025/12/minio-s3-api-alternatives/).
+    Docker images and pre-built binaries are no longer published. RustFS is API-compatible
+    and uses the same port conventions (9000/9001), making migration seamless.
+
+## Installation
+
+```bash
+pip install django-testcontainers-plus[s3]
+```
+
+This installs `boto3`, which is used for bucket creation and is typically already present in projects using `django-storages`.
+
+## Auto-Detection
+
+The provider activates automatically from any of these settings:
+
+| Setting | Detected when |
+|---|---|
+| `STORAGES[*]['BACKEND']` | Contains `s3boto3` |
+| `DEFAULT_FILE_STORAGE` | Contains `s3boto3` |
+| `AWS_STORAGE_BUCKET_NAME` | Present and non-empty |
+
+## Minimal Setup
+
+=== "Django 4.2+ STORAGES"
+
+    ```python title="settings.py"
+    TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'
+
+    STORAGES = {
+        'default': {
+            'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+        }
+    }
+
+    AWS_STORAGE_BUCKET_NAME = 'test-uploads'
+    ```
+
+=== "Legacy DEFAULT_FILE_STORAGE"
+
+    ```python title="settings.py"
+    TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'
+
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    AWS_STORAGE_BUCKET_NAME = 'test-uploads'
+    ```
+
+=== "Static + Media"
+
+    ```python title="settings.py"
+    TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'
+
+    STORAGES = {
+        'default': {
+            'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+        },
+        'staticfiles': {
+            'BACKEND': 'storages.backends.s3boto3.S3StaticStorage',
+        }
+    }
+
+    AWS_STORAGE_BUCKET_NAME = 'test-uploads'
+    ```
+
+    A single S3 container serves both media and static files.
+
+## Default Container
+
+| Property | Value |
+|---|---|
+| Image | `rustfs/rustfs` |
+| S3 API port | Randomly assigned by Docker (maps to 9000) |
+| Console port | Randomly assigned by Docker (maps to 9001) |
+| Access key | `rustfsadmin` |
+| Secret key | `rustfsadmin` |
+
+## Configuration Options
+
+```python title="settings.py"
+TESTCONTAINERS = {
+    's3': {
+        'image': 'rustfs/rustfs',
+        'access_key': 'rustfsadmin',         # used for boto3 + container auth
+        'secret_key': 'rustfsadmin',
+        'bucket_name': 'test-bucket',        # auto-created bucket
+        'environment': {                     # extra container env vars
+            'RUSTFS_CONSOLE_ENABLE': 'true',
+        },
+    }
+}
+```
+
+## Settings Injection
+
+After the S3 container starts, the provider updates your settings automatically:
+
+| Setting | Value |
+|---|---|
+| `AWS_S3_ENDPOINT_URL` | `http://{host}:{port}` pointing to the container |
+| `AWS_ACCESS_KEY_ID` | Container access key (only if not already set) |
+| `AWS_SECRET_ACCESS_KEY` | Container secret key (only if not already set) |
+| `AWS_STORAGE_BUCKET_NAME` | Bucket name (only if not already set) |
+| `S3_CONSOLE_URL` | URL to the RustFS web console |
+
+The provider also auto-creates the bucket specified in `AWS_STORAGE_BUCKET_NAME` (or `test-bucket` by default).
+
+## Example Test
+
+```python
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+
+def test_file_upload():
+    # RustFS container is automatically started and configured
+    content = ContentFile(b"Test file content")
+    path = default_storage.save('uploads/test.txt', content)
+
+    assert default_storage.exists(path)
+    assert default_storage.open(path).read() == b"Test file content"
+
+    default_storage.delete(path)
+    assert not default_storage.exists(path)
+```

--- a/docs/pages/providers/s3.md
+++ b/docs/pages/providers/s3.md
@@ -102,8 +102,8 @@ After the S3 container starts, the provider updates your settings automatically:
 | Setting | Value |
 |---|---|
 | `AWS_S3_ENDPOINT_URL` | `http://{host}:{port}` pointing to the container |
-| `AWS_ACCESS_KEY_ID` | Container access key (only if not already set) |
-| `AWS_SECRET_ACCESS_KEY` | Container secret key (only if not already set) |
+| `AWS_ACCESS_KEY_ID` | Container access key (always overridden to match container) |
+| `AWS_SECRET_ACCESS_KEY` | Container secret key (always overridden to match container) |
 | `AWS_STORAGE_BUCKET_NAME` | Bucket name (only if not already set) |
 | `S3_CONSOLE_URL` | URL to the RustFS web console |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - PostgreSQL: pages/providers/postgres.md
     - MySQL / MariaDB: pages/providers/mysql.md
     - Redis: pages/providers/redis.md
+    - S3 (Object Storage): pages/providers/s3.md
   - API Reference:
     - Overview: pages/api-reference/index.md
     - Providers: pages/api-reference/providers.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "django-testcontainers-plus"
-version = "0.1.3"
-description = "A plug-and-play testcontainers integration for Django - supports databases, Redis, MinIO, and more"
+version = "0.1.4"
+description = "A plug-and-play testcontainers integration for Django - supports databases, Redis, S3, and more"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
     { name = "Andrew Woodward", email = "arwoodward553@gmail.com" }
 ]
 requires-python = ">=3.10"
-keywords = ["django", "testcontainers", "testing", "docker", "containers", "postgres", "mysql", "redis", "mailhog", "email"]
+keywords = ["django", "testcontainers", "testing", "docker", "containers", "postgres", "mysql", "redis", "mailhog", "email", "s3", "boto3", "django-storages"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Django",
@@ -53,9 +53,15 @@ mysql = [
 redis = [
     "redis>=5.0.0",
 ]
+s3 = [
+    "boto3>=1.28.0",
+    "boto3-stubs>=1.28.0",
+]
 all = [
     "mysql-connector-python>=8.0.0",
     "redis>=5.0.0",
+    "boto3>=1.28.0",
+    "boto3-stubs>=1.28.0",
 ]
 
 [project.urls]
@@ -86,6 +92,7 @@ plugins = ["mypy_django_plugin.main"]
 [[tool.mypy.overrides]]
 module = "testcontainers.*"
 ignore_missing_imports = true
+
 
 [tool.django-stubs]
 django_settings_module = "tests.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "ruff>=0.8.0",
     "mypy>=1.8.0",
     "django-stubs>=4.2.0",
+    "boto3-stubs>=1.28.0",
 ]
 docs = [
     "mkdocs-material>=9.0.0",
@@ -55,13 +56,11 @@ redis = [
 ]
 s3 = [
     "boto3>=1.28.0",
-    "boto3-stubs>=1.28.0",
 ]
 all = [
     "mysql-connector-python>=8.0.0",
     "redis>=5.0.0",
     "boto3>=1.28.0",
-    "boto3-stubs>=1.28.0",
 ]
 
 [project.urls]

--- a/src/django_testcontainers_plus/manager.py
+++ b/src/django_testcontainers_plus/manager.py
@@ -187,6 +187,23 @@ class ContainerManager:
             if "redis" in session_engine.lower():
                 return "SESSION_ENGINE"
 
+        elif provider_name == "s3":
+            storages = getattr(self.settings, "STORAGES", {})
+            if isinstance(storages, dict):
+                for storage_name, storage_config in storages.items():
+                    if isinstance(storage_config, dict):
+                        backend = storage_config.get("BACKEND", "")
+                        if "s3boto3" in backend:
+                            return f"STORAGES['{storage_name}']['BACKEND']"
+
+            default_storage = getattr(self.settings, "DEFAULT_FILE_STORAGE", "")
+            if "s3boto3" in default_storage:
+                return "DEFAULT_FILE_STORAGE"
+
+            bucket_name = getattr(self.settings, "AWS_STORAGE_BUCKET_NAME", "")
+            if bucket_name:
+                return "AWS_STORAGE_BUCKET_NAME"
+
         return None
 
     def _raise_missing_dependency_error(

--- a/src/django_testcontainers_plus/manager.py
+++ b/src/django_testcontainers_plus/manager.py
@@ -192,11 +192,11 @@ class ContainerManager:
             if isinstance(storages, dict):
                 for storage_name, storage_config in storages.items():
                     if isinstance(storage_config, dict):
-                        backend = storage_config.get("BACKEND", "")
+                        backend = storage_config.get("BACKEND", "").lower()
                         if "s3boto3" in backend:
                             return f"STORAGES['{storage_name}']['BACKEND']"
 
-            default_storage = getattr(self.settings, "DEFAULT_FILE_STORAGE", "")
+            default_storage = getattr(self.settings, "DEFAULT_FILE_STORAGE", "").lower()
             if "s3boto3" in default_storage:
                 return "DEFAULT_FILE_STORAGE"
 

--- a/src/django_testcontainers_plus/manager.py
+++ b/src/django_testcontainers_plus/manager.py
@@ -192,12 +192,12 @@ class ContainerManager:
             if isinstance(storages, dict):
                 for storage_name, storage_config in storages.items():
                     if isinstance(storage_config, dict):
-                        backend = storage_config.get("BACKEND", "").lower()
-                        if "s3boto3" in backend:
+                        backend = str(storage_config.get("BACKEND", "")).lower()
+                        if "s3boto3" in backend or "storages.backends.s3." in backend:
                             return f"STORAGES['{storage_name}']['BACKEND']"
 
-            default_storage = getattr(self.settings, "DEFAULT_FILE_STORAGE", "").lower()
-            if "s3boto3" in default_storage:
+            default_storage = str(getattr(self.settings, "DEFAULT_FILE_STORAGE", "")).lower()
+            if "s3boto3" in default_storage or "storages.backends.s3." in default_storage:
                 return "DEFAULT_FILE_STORAGE"
 
             bucket_name = getattr(self.settings, "AWS_STORAGE_BUCKET_NAME", "")

--- a/src/django_testcontainers_plus/providers/__init__.py
+++ b/src/django_testcontainers_plus/providers/__init__.py
@@ -32,3 +32,11 @@ try:
     __all__.append("RedisProvider")
 except ImportError as e:
     UNAVAILABLE_PROVIDERS["redis"] = ("redis", e)
+
+try:
+    from .s3 import S3Provider
+
+    PROVIDER_REGISTRY.append(S3Provider())
+    __all__.append("S3Provider")
+except ImportError as e:
+    UNAVAILABLE_PROVIDERS["s3"] = ("s3", e)

--- a/src/django_testcontainers_plus/providers/s3.py
+++ b/src/django_testcontainers_plus/providers/s3.py
@@ -31,8 +31,8 @@ class S3Provider(ContainerProvider):
         """Detect if S3 storage is configured in Django settings.
 
         Checks for:
-        1. Django 4.2+ STORAGES setting with s3boto3 backend
-        2. Legacy DEFAULT_FILE_STORAGE with s3boto3 backend
+        1. Django 4.2+ STORAGES setting with S3 backend
+        2. Legacy DEFAULT_FILE_STORAGE with S3 backend
         3. AWS_STORAGE_BUCKET_NAME present (implies S3 usage)
         """
         # Check Django 4.2+ STORAGES setting
@@ -40,13 +40,13 @@ class S3Provider(ContainerProvider):
         if isinstance(storages, dict):
             for storage_config in storages.values():
                 if isinstance(storage_config, dict):
-                    backend = storage_config.get("BACKEND", "").lower()
-                    if "s3boto3" in backend:
+                    backend = str(storage_config.get("BACKEND", "")).lower()
+                    if self._is_s3_backend(backend):
                         return True
 
         # Check legacy DEFAULT_FILE_STORAGE
-        default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "").lower()
-        if "s3boto3" in default_storage:
+        default_storage = str(getattr(settings, "DEFAULT_FILE_STORAGE", "")).lower()
+        if self._is_s3_backend(default_storage):
             return True
 
         # Check for AWS_STORAGE_BUCKET_NAME (implies S3 usage)
@@ -117,6 +117,11 @@ class S3Provider(ContainerProvider):
             "bucket_name": DEFAULT_BUCKET_NAME,
         }
 
+    @staticmethod
+    def _is_s3_backend(backend: str) -> bool:
+        """Check if a backend string refers to an S3 storage backend."""
+        return "s3boto3" in backend or "storages.backends.s3." in backend
+
     def _create_bucket(
         self,
         endpoint_url: str,
@@ -132,6 +137,7 @@ class S3Provider(ContainerProvider):
             endpoint_url=endpoint_url,
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
+            region_name="us-east-1",
         )
 
         for attempt in range(retries):
@@ -139,10 +145,7 @@ class S3Provider(ContainerProvider):
                 client.create_bucket(Bucket=bucket_name)
                 return
             except ClientError as e:
-                if e.response["Error"]["Code"] in (
-                    "BucketAlreadyOwnedByYou",
-                    "BucketAlreadyExists",
-                ):
+                if e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
                     return
                 raise
             except EndpointConnectionError:

--- a/src/django_testcontainers_plus/providers/s3.py
+++ b/src/django_testcontainers_plus/providers/s3.py
@@ -91,14 +91,10 @@ class S3Provider(ContainerProvider):
 
         updates: dict[str, Any] = {
             "AWS_S3_ENDPOINT_URL": endpoint_url,
+            "AWS_ACCESS_KEY_ID": access_key,
+            "AWS_SECRET_ACCESS_KEY": secret_key,
             "S3_CONSOLE_URL": f"http://{host}:{console_port}",
         }
-
-        # Only set credentials if not already configured in settings
-        if not getattr(settings, "AWS_ACCESS_KEY_ID", ""):
-            updates["AWS_ACCESS_KEY_ID"] = access_key
-        if not getattr(settings, "AWS_SECRET_ACCESS_KEY", ""):
-            updates["AWS_SECRET_ACCESS_KEY"] = secret_key
 
         # Auto-create the bucket
         bucket_name = getattr(settings, "AWS_STORAGE_BUCKET_NAME", "") or config.get(

--- a/src/django_testcontainers_plus/providers/s3.py
+++ b/src/django_testcontainers_plus/providers/s3.py
@@ -1,9 +1,10 @@
 """S3-compatible object storage provider using RustFS."""
 
+import time
 from typing import Any
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
 from testcontainers.core.generic import DockerContainer
 
 from .base import ContainerProvider
@@ -39,12 +40,12 @@ class S3Provider(ContainerProvider):
         if isinstance(storages, dict):
             for storage_config in storages.values():
                 if isinstance(storage_config, dict):
-                    backend = storage_config.get("BACKEND", "")
+                    backend = storage_config.get("BACKEND", "").lower()
                     if "s3boto3" in backend:
                         return True
 
         # Check legacy DEFAULT_FILE_STORAGE
-        default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "")
+        default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "").lower()
         if "s3boto3" in default_storage:
             return True
 
@@ -117,9 +118,15 @@ class S3Provider(ContainerProvider):
         }
 
     def _create_bucket(
-        self, endpoint_url: str, access_key: str, secret_key: str, bucket_name: str
+        self,
+        endpoint_url: str,
+        access_key: str,
+        secret_key: str,
+        bucket_name: str,
+        retries: int = 10,
+        delay: float = 1.0,
     ) -> None:
-        """Create the S3 bucket using boto3."""
+        """Create the S3 bucket using boto3, retrying until the container is ready."""
         client = boto3.client(
             "s3",
             endpoint_url=endpoint_url,
@@ -127,12 +134,18 @@ class S3Provider(ContainerProvider):
             aws_secret_access_key=secret_key,
         )
 
-        try:
-            client.create_bucket(Bucket=bucket_name)
-        except ClientError as e:
-            # Bucket already exists is fine
-            if e.response["Error"]["Code"] not in (
-                "BucketAlreadyOwnedByYou",
-                "BucketAlreadyExists",
-            ):
+        for attempt in range(retries):
+            try:
+                client.create_bucket(Bucket=bucket_name)
+                return
+            except ClientError as e:
+                if e.response["Error"]["Code"] in (
+                    "BucketAlreadyOwnedByYou",
+                    "BucketAlreadyExists",
+                ):
+                    return
                 raise
+            except EndpointConnectionError:
+                if attempt == retries - 1:
+                    raise
+                time.sleep(delay)

--- a/src/django_testcontainers_plus/providers/s3.py
+++ b/src/django_testcontainers_plus/providers/s3.py
@@ -1,0 +1,142 @@
+"""S3-compatible object storage provider using RustFS."""
+
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+from testcontainers.core.generic import DockerContainer
+
+from .base import ContainerProvider
+
+# Default ports for S3-compatible services
+S3_API_PORT = 9000
+CONSOLE_PORT = 9001
+
+# Default credentials for RustFS
+DEFAULT_ACCESS_KEY = "rustfsadmin"
+DEFAULT_SECRET_KEY = "rustfsadmin"
+
+DEFAULT_BUCKET_NAME = "test-bucket"
+
+
+class S3Provider(ContainerProvider):
+    """Provider for S3-compatible object storage containers (RustFS by default)."""
+
+    @property
+    def name(self) -> str:
+        return "s3"
+
+    def can_auto_detect(self, settings: Any, context: dict[str, Any] | None = None) -> bool:
+        """Detect if S3 storage is configured in Django settings.
+
+        Checks for:
+        1. Django 4.2+ STORAGES setting with s3boto3 backend
+        2. Legacy DEFAULT_FILE_STORAGE with s3boto3 backend
+        3. AWS_STORAGE_BUCKET_NAME present (implies S3 usage)
+        """
+        # Check Django 4.2+ STORAGES setting
+        storages = getattr(settings, "STORAGES", {})
+        if isinstance(storages, dict):
+            for storage_config in storages.values():
+                if isinstance(storage_config, dict):
+                    backend = storage_config.get("BACKEND", "")
+                    if "s3boto3" in backend:
+                        return True
+
+        # Check legacy DEFAULT_FILE_STORAGE
+        default_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "")
+        if "s3boto3" in default_storage:
+            return True
+
+        # Check for AWS_STORAGE_BUCKET_NAME (implies S3 usage)
+        bucket_name = getattr(settings, "AWS_STORAGE_BUCKET_NAME", "")
+        if bucket_name:
+            return True
+
+        return False
+
+    def get_container(self, config: dict[str, Any]) -> DockerContainer:
+        """Create S3-compatible container with configuration."""
+        image = config.get("image", "rustfs/rustfs")
+        access_key = config.get("access_key", DEFAULT_ACCESS_KEY)
+        secret_key = config.get("secret_key", DEFAULT_SECRET_KEY)
+
+        container = (
+            DockerContainer(image)
+            .with_exposed_ports(S3_API_PORT, CONSOLE_PORT)
+            .with_env("RUSTFS_ACCESS_KEY", access_key)
+            .with_env("RUSTFS_SECRET_KEY", secret_key)
+            .with_env("RUSTFS_CONSOLE_ENABLE", "true")
+            .with_command("/data")
+        )
+
+        env = config.get("environment", {})
+        for key, value in env.items():
+            container = container.with_env(key, value)
+
+        return container
+
+    def update_settings(
+        self, container: DockerContainer, settings: Any, config: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Update Django settings with container connection info and create bucket."""
+        host = container.get_container_host_ip()
+        api_port = container.get_exposed_port(S3_API_PORT)
+        console_port = container.get_exposed_port(CONSOLE_PORT)
+
+        access_key = config.get("access_key", DEFAULT_ACCESS_KEY)
+        secret_key = config.get("secret_key", DEFAULT_SECRET_KEY)
+
+        endpoint_url = f"http://{host}:{api_port}"
+
+        updates: dict[str, Any] = {
+            "AWS_S3_ENDPOINT_URL": endpoint_url,
+            "S3_CONSOLE_URL": f"http://{host}:{console_port}",
+        }
+
+        # Only set credentials if not already configured in settings
+        if not getattr(settings, "AWS_ACCESS_KEY_ID", ""):
+            updates["AWS_ACCESS_KEY_ID"] = access_key
+        if not getattr(settings, "AWS_SECRET_ACCESS_KEY", ""):
+            updates["AWS_SECRET_ACCESS_KEY"] = secret_key
+
+        # Auto-create the bucket
+        bucket_name = getattr(settings, "AWS_STORAGE_BUCKET_NAME", "") or config.get(
+            "bucket_name", DEFAULT_BUCKET_NAME
+        )
+        self._create_bucket(endpoint_url, access_key, secret_key, bucket_name)
+
+        # Ensure bucket name is set in settings
+        if not getattr(settings, "AWS_STORAGE_BUCKET_NAME", ""):
+            updates["AWS_STORAGE_BUCKET_NAME"] = bucket_name
+
+        return updates
+
+    def get_default_config(self) -> dict[str, Any]:
+        return {
+            "image": "rustfs/rustfs",
+            "access_key": DEFAULT_ACCESS_KEY,
+            "secret_key": DEFAULT_SECRET_KEY,
+            "bucket_name": DEFAULT_BUCKET_NAME,
+        }
+
+    def _create_bucket(
+        self, endpoint_url: str, access_key: str, secret_key: str, bucket_name: str
+    ) -> None:
+        """Create the S3 bucket using boto3."""
+        client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+        try:
+            client.create_bucket(Bucket=bucket_name)
+        except ClientError as e:
+            # Bucket already exists is fine
+            if e.response["Error"]["Code"] not in (
+                "BucketAlreadyOwnedByYou",
+                "BucketAlreadyExists",
+            ):
+                raise

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,9 @@
+"""Shared test helpers."""
+
+
+class MockSettings:
+    """Mock Django settings object for testing."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)

--- a/tests/integration/test_s3_integration.py
+++ b/tests/integration/test_s3_integration.py
@@ -1,0 +1,79 @@
+"""Integration tests for S3Provider with a real RustFS container."""
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from django_testcontainers_plus.providers.s3 import S3Provider
+from tests.test_s3_provider import MockSettings
+
+
+class TestS3Integration:
+    """Test S3Provider against a real RustFS container."""
+
+    @pytest.fixture(autouse=True)
+    def s3_container(self):
+        """Start a real RustFS container for the test class."""
+        provider = S3Provider()
+        config = provider.get_default_config()
+        self.container = provider.get_container(config)
+        self.container.start()
+        self.host = self.container.get_container_host_ip()
+        self.port = self.container.get_exposed_port(9000)
+        self.endpoint_url = f"http://{self.host}:{self.port}"
+
+        yield
+
+        self.container.stop()
+
+    def _get_client(self):
+        return boto3.client(
+            "s3",
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id="rustfsadmin",
+            aws_secret_access_key="rustfsadmin",
+        )
+
+    def test_container_starts_and_accepts_connections(self):
+        client = self._get_client()
+        response = client.list_buckets()
+        assert "Buckets" in response
+
+    def test_create_bucket(self):
+        client = self._get_client()
+        client.create_bucket(Bucket="integration-test")
+        buckets = [b["Name"] for b in client.list_buckets()["Buckets"]]
+        assert "integration-test" in buckets
+
+    def test_put_and_get_object(self):
+        client = self._get_client()
+        client.create_bucket(Bucket="object-test")
+        client.put_object(Bucket="object-test", Key="hello.txt", Body=b"hello world")
+
+        obj = client.get_object(Bucket="object-test", Key="hello.txt")
+        assert obj["Body"].read() == b"hello world"
+
+    def test_delete_object(self):
+        client = self._get_client()
+        client.create_bucket(Bucket="delete-test")
+        client.put_object(Bucket="delete-test", Key="temp.txt", Body=b"temporary")
+        client.delete_object(Bucket="delete-test", Key="temp.txt")
+
+        with pytest.raises(ClientError) as exc_info:
+            client.get_object(Bucket="delete-test", Key="temp.txt")
+        assert exc_info.value.response["Error"]["Code"] == "NoSuchKey"
+
+    def test_provider_update_settings_creates_bucket(self):
+        """Test the full update_settings flow with a real container."""
+        settings = MockSettings(AWS_STORAGE_BUCKET_NAME="auto-created")
+        provider = S3Provider()
+        config = provider.get_default_config()
+
+        updates = provider.update_settings(self.container, settings, config)
+
+        assert updates["AWS_S3_ENDPOINT_URL"] == self.endpoint_url
+
+        # Verify bucket was actually created
+        client = self._get_client()
+        buckets = [b["Name"] for b in client.list_buckets()["Buckets"]]
+        assert "auto-created" in buckets

--- a/tests/integration/test_s3_integration.py
+++ b/tests/integration/test_s3_integration.py
@@ -11,20 +11,22 @@ from tests.test_s3_provider import MockSettings
 class TestS3Integration:
     """Test S3Provider against a real RustFS container."""
 
-    @pytest.fixture(autouse=True)
-    def s3_container(self):
+    @pytest.fixture(scope="class", autouse=True)
+    def s3_container(self, request):
         """Start a real RustFS container for the test class."""
         provider = S3Provider()
         config = provider.get_default_config()
-        self.container = provider.get_container(config)
-        self.container.start()
-        self.host = self.container.get_container_host_ip()
-        self.port = self.container.get_exposed_port(9000)
-        self.endpoint_url = f"http://{self.host}:{self.port}"
+        container = provider.get_container(config)
+        container.start()
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(9000)
+
+        request.cls.container = container
+        request.cls.endpoint_url = f"http://{host}:{port}"
 
         yield
 
-        self.container.stop()
+        container.stop()
 
     def _get_client(self):
         return boto3.client(

--- a/tests/integration/test_s3_integration.py
+++ b/tests/integration/test_s3_integration.py
@@ -1,11 +1,32 @@
 """Integration tests for S3Provider with a real RustFS container."""
 
+import time
+
 import boto3
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
 
 from django_testcontainers_plus.providers.s3 import S3Provider
 from tests.helpers import MockSettings
+
+
+def _wait_for_s3(endpoint_url: str, retries: int = 10, delay: float = 1.0) -> None:
+    """Wait until the S3 endpoint is accepting connections."""
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        aws_access_key_id="rustfsadmin",
+        aws_secret_access_key="rustfsadmin",
+        region_name="us-east-1",
+    )
+    for attempt in range(retries):
+        try:
+            client.list_buckets()
+            return
+        except (EndpointConnectionError, ConnectionError):
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay)
 
 
 class TestS3Integration:
@@ -20,9 +41,12 @@ class TestS3Integration:
         container.start()
         host = container.get_container_host_ip()
         port = container.get_exposed_port(9000)
+        endpoint_url = f"http://{host}:{port}"
+
+        _wait_for_s3(endpoint_url)
 
         request.cls.container = container
-        request.cls.endpoint_url = f"http://{host}:{port}"
+        request.cls.endpoint_url = endpoint_url
 
         yield
 
@@ -34,6 +58,7 @@ class TestS3Integration:
             endpoint_url=self.endpoint_url,
             aws_access_key_id="rustfsadmin",
             aws_secret_access_key="rustfsadmin",
+            region_name="us-east-1",
         )
 
     def test_container_starts_and_accepts_connections(self):

--- a/tests/integration/test_s3_integration.py
+++ b/tests/integration/test_s3_integration.py
@@ -5,7 +5,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from django_testcontainers_plus.providers.s3 import S3Provider
-from tests.test_s3_provider import MockSettings
+from tests.helpers import MockSettings
 
 
 class TestS3Integration:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,14 +9,7 @@ from django_testcontainers_plus.exceptions import (
     MissingDependencyError,
 )
 from django_testcontainers_plus.manager import ContainerManager
-
-
-class MockSettings:
-    """Mock Django settings object."""
-
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+from tests.helpers import MockSettings
 
 
 class TestMissingDependencyError:

--- a/tests/test_mailhog_provider.py
+++ b/tests/test_mailhog_provider.py
@@ -3,14 +3,7 @@
 from unittest.mock import Mock, patch
 
 from django_testcontainers_plus.providers.mailhog import MailhogProvider
-
-
-class MockSettings:
-    """Mock Django settings object."""
-
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+from tests.helpers import MockSettings
 
 
 class TestMailhogProvider:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -4,14 +4,7 @@ from unittest.mock import Mock
 
 from django_testcontainers_plus.manager import ContainerManager
 from django_testcontainers_plus.providers.base import ContainerProvider
-
-
-class MockSettings:
-    """Mock Django settings object."""
-
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+from tests.helpers import MockSettings
 
 
 class MockProvider(ContainerProvider):

--- a/tests/test_postgres_provider.py
+++ b/tests/test_postgres_provider.py
@@ -3,14 +3,7 @@
 from unittest.mock import Mock, patch
 
 from django_testcontainers_plus.providers.postgres import PostgresProvider
-
-
-class MockSettings:
-    """Mock Django settings object."""
-
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+from tests.helpers import MockSettings
 
 
 class TestPostgresProvider:

--- a/tests/test_s3_provider.py
+++ b/tests/test_s3_provider.py
@@ -51,6 +51,20 @@ class TestS3Provider:
         settings = MockSettings(DEFAULT_FILE_STORAGE="storages.backends.s3boto3.S3Boto3Storage")
         assert S3Provider().can_auto_detect(settings) is True
 
+    def test_can_auto_detect_modern_s3_backend(self):
+        settings = MockSettings(
+            STORAGES={
+                "default": {
+                    "BACKEND": "storages.backends.s3.S3Storage",
+                }
+            }
+        )
+        assert S3Provider().can_auto_detect(settings) is True
+
+    def test_can_auto_detect_modern_s3_default_file_storage(self):
+        settings = MockSettings(DEFAULT_FILE_STORAGE="storages.backends.s3.S3Storage")
+        assert S3Provider().can_auto_detect(settings) is True
+
     def test_can_auto_detect_aws_bucket_name(self):
         settings = MockSettings(AWS_STORAGE_BUCKET_NAME="my-bucket")
         assert S3Provider().can_auto_detect(settings) is True

--- a/tests/test_s3_provider.py
+++ b/tests/test_s3_provider.py
@@ -1,0 +1,274 @@
+"""Tests for S3Provider."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from django_testcontainers_plus.providers.s3 import S3Provider
+
+
+class MockSettings:
+    """Mock Django settings object."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _mock_container(host="127.0.0.1", api_port=32768, console_port=32769):
+    """Create a mock container with standard port mappings."""
+    container = Mock()
+    container.get_container_host_ip.return_value = host
+    port_map = {9000: api_port, 9001: console_port}
+    container.get_exposed_port.side_effect = lambda p: port_map[p]
+    return container
+
+
+class TestS3Provider:
+    """Test S3Provider class."""
+
+    def test_name(self):
+        provider = S3Provider()
+        assert provider.name == "s3"
+
+    # --- Auto-detection tests ---
+
+    def test_can_auto_detect_storages_s3boto3(self):
+        settings = MockSettings(
+            STORAGES={
+                "default": {
+                    "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+                }
+            }
+        )
+        assert S3Provider().can_auto_detect(settings) is True
+
+    def test_can_auto_detect_staticfiles_s3(self):
+        settings = MockSettings(
+            STORAGES={
+                "staticfiles": {
+                    "BACKEND": "storages.backends.s3boto3.S3StaticStorage",
+                }
+            }
+        )
+        assert S3Provider().can_auto_detect(settings) is True
+
+    def test_can_auto_detect_legacy_default_file_storage(self):
+        settings = MockSettings(DEFAULT_FILE_STORAGE="storages.backends.s3boto3.S3Boto3Storage")
+        assert S3Provider().can_auto_detect(settings) is True
+
+    def test_can_auto_detect_aws_bucket_name(self):
+        settings = MockSettings(AWS_STORAGE_BUCKET_NAME="my-bucket")
+        assert S3Provider().can_auto_detect(settings) is True
+
+    def test_can_auto_detect_no_s3_config(self):
+        settings = MockSettings()
+        assert S3Provider().can_auto_detect(settings) is False
+
+    def test_can_auto_detect_non_s3_storage(self):
+        settings = MockSettings(
+            STORAGES={
+                "default": {
+                    "BACKEND": "django.core.files.storage.FileSystemStorage",
+                }
+            }
+        )
+        assert S3Provider().can_auto_detect(settings) is False
+
+    def test_can_auto_detect_empty_bucket_name(self):
+        settings = MockSettings(AWS_STORAGE_BUCKET_NAME="")
+        assert S3Provider().can_auto_detect(settings) is False
+
+    def test_can_auto_detect_storages_not_dict(self):
+        settings = MockSettings(STORAGES="not-a-dict")
+        assert S3Provider().can_auto_detect(settings) is False
+
+    # --- Container creation tests ---
+
+    @patch("django_testcontainers_plus.providers.s3.DockerContainer")
+    def test_get_container_defaults(self, mock_docker_container):
+        mock_instance = Mock()
+        mock_instance.with_exposed_ports.return_value = mock_instance
+        mock_instance.with_env.return_value = mock_instance
+        mock_instance.with_command.return_value = mock_instance
+        mock_docker_container.return_value = mock_instance
+
+        provider = S3Provider()
+        container = provider.get_container(provider.get_default_config())
+
+        # Verify the image used
+        assert mock_docker_container.call_args[0][0] == "rustfs/rustfs"
+
+        # Verify ports and command via the chain
+        assert mock_instance.with_exposed_ports.call_args[0] == (9000, 9001)
+        assert mock_instance.with_command.call_args[0] == ("/data",)
+
+        # Verify env vars were set by collecting all with_env calls
+        env_calls = {call[0][0]: call[0][1] for call in mock_instance.with_env.call_args_list}
+        assert env_calls["RUSTFS_ACCESS_KEY"] == "rustfsadmin"
+        assert env_calls["RUSTFS_SECRET_KEY"] == "rustfsadmin"
+        assert env_calls["RUSTFS_CONSOLE_ENABLE"] == "true"
+        assert container == mock_instance
+
+    @patch("django_testcontainers_plus.providers.s3.DockerContainer")
+    def test_get_container_custom_image(self, mock_docker_container):
+        mock_instance = Mock()
+        mock_instance.with_exposed_ports.return_value = mock_instance
+        mock_instance.with_env.return_value = mock_instance
+        mock_instance.with_command.return_value = mock_instance
+        mock_docker_container.return_value = mock_instance
+
+        config = {
+            "image": "dxflrs/garage",
+            "access_key": "rustfsadmin",
+            "secret_key": "rustfsadmin",
+        }
+        S3Provider().get_container(config)
+
+        assert mock_docker_container.call_args[0][0] == "dxflrs/garage"
+
+    @patch("django_testcontainers_plus.providers.s3.DockerContainer")
+    def test_get_container_custom_credentials(self, mock_docker_container):
+        mock_instance = Mock()
+        mock_instance.with_exposed_ports.return_value = mock_instance
+        mock_instance.with_env.return_value = mock_instance
+        mock_instance.with_command.return_value = mock_instance
+        mock_docker_container.return_value = mock_instance
+
+        S3Provider().get_container({"access_key": "mykey", "secret_key": "mysecret"})
+
+        env_calls = {call[0][0]: call[0][1] for call in mock_instance.with_env.call_args_list}
+        assert env_calls["RUSTFS_ACCESS_KEY"] == "mykey"
+        assert env_calls["RUSTFS_SECRET_KEY"] == "mysecret"
+
+    @patch("django_testcontainers_plus.providers.s3.DockerContainer")
+    def test_get_container_with_environment(self, mock_docker_container):
+        mock_instance = Mock()
+        mock_instance.with_exposed_ports.return_value = mock_instance
+        mock_instance.with_env.return_value = mock_instance
+        mock_instance.with_command.return_value = mock_instance
+        mock_docker_container.return_value = mock_instance
+
+        config = {
+            "access_key": "rustfsadmin",
+            "secret_key": "rustfsadmin",
+            "environment": {
+                "RUSTFS_ADDRESS": ":9000",
+                "RUSTFS_SERVER_DOMAINS": "example.com",
+            },
+        }
+        S3Provider().get_container(config)
+
+        env_calls = {call[0][0]: call[0][1] for call in mock_instance.with_env.call_args_list}
+        assert env_calls["RUSTFS_ADDRESS"] == ":9000"
+        assert env_calls["RUSTFS_SERVER_DOMAINS"] == "example.com"
+
+    # --- Settings update tests (bucket creation patched out) ---
+
+    @patch.object(S3Provider, "_create_bucket")
+    def test_update_settings(self, mock_create_bucket):
+        settings = MockSettings(AWS_STORAGE_BUCKET_NAME="test-uploads")
+        config = S3Provider().get_default_config()
+
+        updates = S3Provider().update_settings(_mock_container(), settings, config)
+
+        assert updates["AWS_S3_ENDPOINT_URL"] == "http://127.0.0.1:32768"
+        assert updates["S3_CONSOLE_URL"] == "http://127.0.0.1:32769"
+        assert updates["AWS_ACCESS_KEY_ID"] == "rustfsadmin"
+        assert updates["AWS_SECRET_ACCESS_KEY"] == "rustfsadmin"
+
+    @patch.object(S3Provider, "_create_bucket")
+    def test_update_settings_preserves_existing_credentials(self, mock_create_bucket):
+        settings = MockSettings(
+            AWS_ACCESS_KEY_ID="existing-key",
+            AWS_SECRET_ACCESS_KEY="existing-secret",
+            AWS_STORAGE_BUCKET_NAME="my-bucket",
+        )
+        config = S3Provider().get_default_config()
+
+        updates = S3Provider().update_settings(_mock_container(), settings, config)
+
+        assert "AWS_ACCESS_KEY_ID" not in updates
+        assert "AWS_SECRET_ACCESS_KEY" not in updates
+
+    @patch.object(S3Provider, "_create_bucket")
+    def test_update_settings_default_bucket(self, mock_create_bucket):
+        settings = MockSettings()
+        config = S3Provider().get_default_config()
+
+        updates = S3Provider().update_settings(_mock_container(), settings, config)
+
+        assert updates["AWS_STORAGE_BUCKET_NAME"] == "test-bucket"
+
+    @patch.object(S3Provider, "_create_bucket")
+    def test_update_settings_config_bucket_name(self, mock_create_bucket):
+        settings = MockSettings()
+        config = {**S3Provider().get_default_config(), "bucket_name": "custom-bucket"}
+
+        updates = S3Provider().update_settings(_mock_container(), settings, config)
+
+        assert updates["AWS_STORAGE_BUCKET_NAME"] == "custom-bucket"
+
+    @patch.object(S3Provider, "_create_bucket")
+    def test_update_settings_skips_bucket_name_when_already_set(self, mock_create_bucket):
+        settings = MockSettings(AWS_STORAGE_BUCKET_NAME="existing-bucket")
+        config = S3Provider().get_default_config()
+
+        updates = S3Provider().update_settings(_mock_container(), settings, config)
+
+        assert "AWS_STORAGE_BUCKET_NAME" not in updates
+
+    # --- Bucket creation tests ---
+
+    @patch("boto3.client")
+    def test_create_bucket(self, mock_boto3_client):
+        mock_s3 = Mock()
+        mock_boto3_client.return_value = mock_s3
+
+        S3Provider()._create_bucket(
+            "http://localhost:9000", "rustfsadmin", "rustfsadmin", "my-bucket"
+        )
+
+        created_bucket = mock_s3.create_bucket.call_args[1]["Bucket"]
+        assert created_bucket == "my-bucket"
+
+    @patch("boto3.client")
+    def test_create_bucket_already_exists(self, mock_boto3_client):
+        mock_s3 = Mock()
+        mock_s3.create_bucket.side_effect = ClientError(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": ""}},
+            "CreateBucket",
+        )
+        mock_boto3_client.return_value = mock_s3
+
+        # Should not raise
+        S3Provider()._create_bucket(
+            "http://localhost:9000", "rustfsadmin", "rustfsadmin", "my-bucket"
+        )
+
+    @patch("boto3.client")
+    def test_create_bucket_unexpected_error_raises(self, mock_boto3_client):
+        mock_s3 = Mock()
+        mock_s3.create_bucket.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+            "CreateBucket",
+        )
+        mock_boto3_client.return_value = mock_s3
+
+        with pytest.raises(ClientError):
+            S3Provider()._create_bucket(
+                "http://localhost:9000", "rustfsadmin", "rustfsadmin", "my-bucket"
+            )
+
+    # --- Default config test ---
+
+    def test_get_default_config(self):
+        config = S3Provider().get_default_config()
+
+        assert config == {
+            "image": "rustfs/rustfs",
+            "access_key": "rustfsadmin",
+            "secret_key": "rustfsadmin",
+            "bucket_name": "test-bucket",
+        }

--- a/tests/test_s3_provider.py
+++ b/tests/test_s3_provider.py
@@ -179,7 +179,7 @@ class TestS3Provider:
         assert updates["AWS_SECRET_ACCESS_KEY"] == "rustfsadmin"
 
     @patch.object(S3Provider, "_create_bucket")
-    def test_update_settings_preserves_existing_credentials(self, mock_create_bucket):
+    def test_update_settings_overrides_existing_credentials(self, mock_create_bucket):
         settings = MockSettings(
             AWS_ACCESS_KEY_ID="existing-key",
             AWS_SECRET_ACCESS_KEY="existing-secret",
@@ -189,8 +189,8 @@ class TestS3Provider:
 
         updates = S3Provider().update_settings(_mock_container(), settings, config)
 
-        assert "AWS_ACCESS_KEY_ID" not in updates
-        assert "AWS_SECRET_ACCESS_KEY" not in updates
+        assert updates["AWS_ACCESS_KEY_ID"] == "rustfsadmin"
+        assert updates["AWS_SECRET_ACCESS_KEY"] == "rustfsadmin"
 
     @patch.object(S3Provider, "_create_bucket")
     def test_update_settings_default_bucket(self, mock_create_bucket):

--- a/tests/test_s3_provider.py
+++ b/tests/test_s3_provider.py
@@ -6,14 +6,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from django_testcontainers_plus.providers.s3 import S3Provider
-
-
-class MockSettings:
-    """Mock Django settings object."""
-
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+from tests.helpers import MockSettings
 
 
 def _mock_container(host="127.0.0.1", api_port=32768, console_port=32769):

--- a/uv.lock
+++ b/uv.lock
@@ -420,11 +420,11 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "boto3" },
-    { name = "boto3-stubs" },
     { name = "mysql-connector-python" },
     { name = "redis" },
 ]
 dev = [
+    { name = "boto3-stubs" },
     { name = "django-stubs" },
     { name = "mypy" },
     { name = "pytest" },
@@ -444,15 +444,13 @@ redis = [
 ]
 s3 = [
     { name = "boto3" },
-    { name = "boto3-stubs" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.28.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28.0" },
-    { name = "boto3-stubs", marker = "extra == 'all'", specifier = ">=1.28.0" },
-    { name = "boto3-stubs", marker = "extra == 's3'", specifier = ">=1.28.0" },
+    { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.28.0" },
     { name = "django", specifier = ">=4.2" },
     { name = "django-stubs", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -48,6 +48,60 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
     { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
     { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/13/33c8b8704d677fcaf5555ba8c6cc39468fc7b9a0c6b6c496e008cd5557fc/boto3-1.42.76.tar.gz", hash = "sha256:aa2b1973eee8973a9475d24bb579b1dee7176595338d4e4f7880b5c6189b8814", size = 112789, upload-time = "2026-03-25T19:33:25.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/dc/21b3dfb135125eb7e3a46b9aab0aede847726f239fc8f39474742a87ebb0/boto3-1.42.76-py3-none-any.whl", hash = "sha256:63c6779c814847016b89ae1b72ed968f8a63d80e589ba337511aa6fc1b59585e", size = 140557, upload-time = "2026-03-25T19:33:23.289Z" },
+]
+
+[[package]]
+name = "boto3-stubs"
+version = "1.42.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/80/78461434f660ce8f2f5160f8fd6eda2152d5ea6b8abbc6a72741d19a6551/boto3_stubs-1.42.76.tar.gz", hash = "sha256:13863d2dc56a3df2f7e35b6cc5b9fe6dcc9024c24357ad470648f60ad4a7c9b7", size = 101580, upload-time = "2026-03-25T19:39:44.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/46/e51cb3cf6ec14780ad14fbf16faf36fd794ac5c09e39fb4b20c7630928b3/boto3_stubs-1.42.76-py3-none-any.whl", hash = "sha256:6a56ab2838bac7891c58f19c533cdf25dfaadee49ee1d58c4551363291cb59f9", size = 70162, upload-time = "2026-03-25T19:39:33.24Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/62/a982acb81c5e0312f90f841b790abad65622c08aad356eed7008ea3d475b/botocore-1.42.76.tar.gz", hash = "sha256:c553fa0ae29e36a5c407f74da78b78404b81b74b15fb62bf640a3cd9385f0874", size = 15021811, upload-time = "2026-03-25T19:33:12.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/63/7429d68876b7718ab5c4b8a44414de7907f5ba6bb27ccfad384df14fb277/botocore-1.42.76-py3-none-any.whl", hash = "sha256:151e714ae3c32f68ea0b4dc60751401e03f84a87c6cf864ea0ee64aa10eb4607", size = 14697736, upload-time = "2026-03-25T19:33:07.573Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.42.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
 ]
 
 [[package]]
@@ -354,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "django-testcontainers-plus"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -365,6 +419,8 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "boto3" },
+    { name = "boto3-stubs" },
     { name = "mysql-connector-python" },
     { name = "redis" },
 ]
@@ -386,9 +442,17 @@ mysql = [
 redis = [
     { name = "redis" },
 ]
+s3 = [
+    { name = "boto3" },
+    { name = "boto3-stubs" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.28.0" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28.0" },
+    { name = "boto3-stubs", marker = "extra == 'all'", specifier = ">=1.28.0" },
+    { name = "boto3-stubs", marker = "extra == 's3'", specifier = ">=1.28.0" },
     { name = "django", specifier = ">=4.2" },
     { name = "django-stubs", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
@@ -405,7 +469,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "testcontainers", specifier = ">=4.0.0" },
 ]
-provides-extras = ["dev", "docs", "mysql", "redis", "all"]
+provides-extras = ["dev", "docs", "mysql", "redis", "s3", "all"]
 
 [[package]]
 name = "docker"
@@ -449,6 +513,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -481,6 +546,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1163,6 +1237,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,12 +1337,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-awscrt"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `S3Provider` using RustFS as the default S3-compatible backend, with auto-detection from `STORAGES`, `DEFAULT_FILE_STORAGE`, and `AWS_STORAGE_BUCKET_NAME`
- Automatic bucket creation via boto3, credentials injection, and backend-agnostic image configuration
- Introduces integration test infrastructure (`pytest -m integration` / `make test-integration`) with real container tests against RustFS
- Consolidates CI by replacing `django-tests` job with a proper `integration` job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 (object storage) support added with auto-detection from Django storage settings.

* **Documentation**
  * New S3 provider docs, installation instructions, and examples added.

* **Tests**
  * New unit and integration tests covering S3 provider behavior and end-to-end interactions.

* **Chores**
  * Package bumped to 0.1.4 with S3-related metadata and optional dependency groups; CI workflow simplified (tests job consolidated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->