### PR TITLE
Support Django 5.2–6.1 and Mailhog MAILERS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,26 @@ on:
 
 jobs:
   tests:
-    name: Tests (Python ${{ matrix.python-version }})
+    name: Tests (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python-version: "3.10"
+            django-version: "5.2"
+          - python-version: "3.11"
+            django-version: "5.2"
+          - python-version: "3.12"
+            django-version: "5.2"
+          - python-version: "3.12"
+            django-version: "6.0"
+          - python-version: "3.12"
+            django-version: "6.1"
+          - python-version: "3.13"
+            django-version: "6.1"
+          - python-version: "3.14"
+            django-version: "6.1"
 
     steps:
       - uses: actions/checkout@v4
@@ -31,17 +45,18 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --all-extras --dev
+          uv pip install "django~=${{ matrix.django-version }}.0"
 
       - name: Run tests
         run: make coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.13' && matrix.django-version == '6.1'
         with:
           file: ./coverage.xml
           flags: tests
-          name: tests-py${{ matrix.python-version }}
+          name: tests-py${{ matrix.python-version }}-dj${{ matrix.django-version }}
 
   code-quality:
     name: Code Quality

--- a/docs/pages/getting-started/installation.md
+++ b/docs/pages/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python **3.10+**
-- Django **4.2+**
+- Django **5.2+**
 - Docker (running locally or in CI)
 
 ## Basic Installation

--- a/docs/pages/help/changelog.md
+++ b/docs/pages/help/changelog.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.5] - Latest
 
 ### Changed
+- Require Django 5.2+ and declare support for Django 5.2, 6.0, and 6.1
 - Require `testcontainers>=4.15.0` and import Postgres, MySQL, and Redis containers from `testcontainers.community` to silence deprecation warnings
+
+### Added
+- Mailhog auto-detection and settings updates for Django 6.1 `MAILERS`
 
 ## [0.1.4]
 

--- a/docs/pages/providers/s3.md
+++ b/docs/pages/providers/s3.md
@@ -27,7 +27,7 @@ The provider activates automatically from any of these settings:
 
 ## Minimal Setup
 
-=== "Django 4.2+ STORAGES"
+=== "STORAGES"
 
     ```python title="settings.py"
     TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ keywords = ["django", "testcontainers", "testing", "docker", "containers", "post
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Framework :: Pytest",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "django>=4.2",
+    "django>=5.2",
     "pytest>=9.0.1",
     "testcontainers>=4.15.0",
 ]

--- a/src/django_testcontainers_plus/providers/mailhog.py
+++ b/src/django_testcontainers_plus/providers/mailhog.py
@@ -116,9 +116,9 @@ class MailhogProvider(ContainerProvider):
     ) -> dict[str, Any]:
         """Update email settings with container connection info.
 
-        When MAILERS is defined (Django 6.1+), patch the default mailer OPTIONS
-        instead of the deprecated EMAIL_* settings. Otherwise keep the EMAIL_*
-        path for Django 5.2 / 6.0.
+        Always point EMAIL_* at Mailhog so leftover deprecated settings cannot
+        send real email. When MAILERS is defined (Django 6.1+), also patch the
+        default mailer OPTIONS.
         """
         host = container.get_container_host_ip()
         smtp_port = int(container.get_exposed_port(SMTP_PORT))
@@ -126,6 +126,12 @@ class MailhogProvider(ContainerProvider):
 
         updates: dict[str, Any] = {
             "MAILHOG_API_URL": f"http://{host}:{http_port}/api/v2",
+            # Restore SMTP backend (Django's test setup may have set it to locmem)
+            "EMAIL_BACKEND": SMTP_BACKEND,
+            "EMAIL_HOST": host,
+            "EMAIL_PORT": smtp_port,
+            "EMAIL_USE_TLS": False,
+            "EMAIL_USE_SSL": False,
         }
 
         mailers = getattr(settings, "MAILERS", None)
@@ -147,18 +153,7 @@ class MailhogProvider(ContainerProvider):
                     "OPTIONS": options,
                 }
             }
-            return updates
 
-        updates.update(
-            {
-                # Restore SMTP backend (Django's test setup may have set it to locmem)
-                "EMAIL_BACKEND": SMTP_BACKEND,
-                "EMAIL_HOST": host,
-                "EMAIL_PORT": smtp_port,
-                "EMAIL_USE_TLS": False,
-                "EMAIL_USE_SSL": False,
-            }
-        )
         return updates
 
     def get_default_config(self) -> dict[str, Any]:

--- a/src/django_testcontainers_plus/providers/mailhog.py
+++ b/src/django_testcontainers_plus/providers/mailhog.py
@@ -10,6 +10,8 @@ from .base import ContainerProvider
 SMTP_PORT = 1025
 HTTP_PORT = 8025
 
+SMTP_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
 # Django email backends that don't need Mailhog
 SKIP_BACKENDS = (
     "django.core.mail.backends.console.EmailBackend",
@@ -17,6 +19,32 @@ SKIP_BACKENDS = (
     "django.core.mail.backends.locmem.EmailBackend",
     "django.core.mail.backends.dummy.EmailBackend",
 )
+
+
+def _mailers_default(mailers: Any) -> dict[str, Any] | None:
+    """Return the default mailer config if MAILERS is a dict with a default entry."""
+    if not isinstance(mailers, dict):
+        return None
+    default = mailers.get("default")
+    return default if isinstance(default, dict) else None
+
+
+def _mailers_backend(mailers: Any) -> str | None:
+    """Return BACKEND from MAILERS['default'], if set."""
+    default = _mailers_default(mailers)
+    if default is None:
+        return None
+    backend = default.get("BACKEND")
+    return backend if isinstance(backend, str) else None
+
+
+def _mailers_has_host(mailers: Any) -> bool:
+    """Return True if MAILERS['default']['OPTIONS']['host'] is set."""
+    default = _mailers_default(mailers)
+    if default is None:
+        return False
+    options = default.get("OPTIONS") or {}
+    return isinstance(options, dict) and bool(options.get("host"))
 
 
 class MailhogProvider(ContainerProvider):
@@ -29,13 +57,15 @@ class MailhogProvider(ContainerProvider):
     def can_auto_detect(self, settings: Any, context: dict[str, Any] | None = None) -> bool:
         """Detect if SMTP email backend is configured.
 
-        Uses original_email_backend from context when available, since Django's
-        test setup overwrites EMAIL_BACKEND with locmem before detection runs.
-        See: https://docs.djangoproject.com/en/5.2/topics/testing/tools/#email-services
+        Uses original values from context when available, since Django's test
+        setup overwrites EMAIL_BACKEND (and MAILERS, when defined) with locmem
+        before detection runs.
+        See: https://docs.djangoproject.com/en/6.1/topics/testing/tools/#email-services
 
         Mailhog should be used when:
+        - MAILERS['default']['BACKEND'] is smtp.EmailBackend (Django 6.1+)
         - EMAIL_BACKEND is smtp.EmailBackend (explicit)
-        - EMAIL_BACKEND is not set (defaults to SMTP in Django)
+        - No backend is set, but EMAIL_HOST or MAILERS OPTIONS host is configured
 
         Mailhog should NOT be used when:
         - Console backend (prints to console)
@@ -43,24 +73,31 @@ class MailhogProvider(ContainerProvider):
         - In-memory backend (for testing without SMTP)
         - Dummy backend (discards emails)
         """
-        if context and context.get("original_email_backend") is not None:
-            email_backend = context["original_email_backend"]
-        else:
+        mailers = None
+        email_backend = None
+
+        if context:
+            if context.get("original_mailers") is not None:
+                mailers = context["original_mailers"]
+            if context.get("original_email_backend") is not None:
+                email_backend = context["original_email_backend"]
+
+        if mailers is None:
+            mailers = getattr(settings, "MAILERS", None)
+        if email_backend is None:
             email_backend = getattr(settings, "EMAIL_BACKEND", None)
 
-        # If no backend is set, Django defaults to SMTP, but we shouldn't auto-enable
-        # Mailhog unless there's an explicit SMTP backend or EMAIL_HOST is configured
-        if email_backend is None:
-            # Check if there's explicit email configuration suggesting SMTP usage
-            email_host = getattr(settings, "EMAIL_HOST", "")
-            return bool(email_host)
+        backend = _mailers_backend(mailers)
+        if backend is None:
+            backend = email_backend
 
-        # Skip non-SMTP backends
-        if email_backend in SKIP_BACKENDS:
+        if backend is None:
+            return _mailers_has_host(mailers) or bool(getattr(settings, "EMAIL_HOST", ""))
+
+        if backend in SKIP_BACKENDS:
             return False
 
-        # Detect SMTP backend
-        return bool(email_backend == "django.core.mail.backends.smtp.EmailBackend")
+        return backend == SMTP_BACKEND
 
     def get_container(self, config: dict[str, Any]) -> DockerContainer:
         """Create Mailhog container with configuration."""
@@ -77,22 +114,51 @@ class MailhogProvider(ContainerProvider):
     def update_settings(
         self, container: DockerContainer, settings: Any, config: dict[str, Any]
     ) -> dict[str, Any]:
-        """Update email settings with container connection info."""
+        """Update email settings with container connection info.
+
+        When MAILERS is defined (Django 6.1+), patch the default mailer OPTIONS
+        instead of the deprecated EMAIL_* settings. Otherwise keep the EMAIL_*
+        path for Django 5.2 / 6.0.
+        """
         host = container.get_container_host_ip()
-        smtp_port = container.get_exposed_port(SMTP_PORT)
+        smtp_port = int(container.get_exposed_port(SMTP_PORT))
         http_port = container.get_exposed_port(HTTP_PORT)
 
         updates: dict[str, Any] = {
-            # Restore SMTP backend (Django's test setup may have set it to locmem)
-            "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
-            "EMAIL_HOST": host,
-            "EMAIL_PORT": int(smtp_port),
-            "EMAIL_USE_TLS": False,
-            "EMAIL_USE_SSL": False,
-            # Store the API URL for retrieving sent emails in tests
             "MAILHOG_API_URL": f"http://{host}:{http_port}/api/v2",
         }
 
+        mailers = getattr(settings, "MAILERS", None)
+        if isinstance(mailers, dict) and mailers:
+            default = dict(_mailers_default(mailers) or {})
+            options = dict(default.get("OPTIONS") or {})
+            options.update(
+                {
+                    "host": host,
+                    "port": smtp_port,
+                    "use_tls": False,
+                    "use_ssl": False,
+                }
+            )
+            updates["MAILERS"] = {
+                "default": {
+                    **default,
+                    "BACKEND": SMTP_BACKEND,
+                    "OPTIONS": options,
+                }
+            }
+            return updates
+
+        updates.update(
+            {
+                # Restore SMTP backend (Django's test setup may have set it to locmem)
+                "EMAIL_BACKEND": SMTP_BACKEND,
+                "EMAIL_HOST": host,
+                "EMAIL_PORT": smtp_port,
+                "EMAIL_USE_TLS": False,
+                "EMAIL_USE_SSL": False,
+            }
+        )
         return updates
 
     def get_default_config(self) -> dict[str, Any]:

--- a/src/django_testcontainers_plus/pytest_plugin.py
+++ b/src/django_testcontainers_plus/pytest_plugin.py
@@ -16,13 +16,14 @@ def pytest_configure(config: pytest.Config) -> None:
     """Capture original Django settings before test setup overwrites them.
 
     Django's setup_test_environment() overwrites certain settings
-    (e.g. EMAIL_BACKEND is set to locmem). We capture originals here
-    so providers can use them for auto-detection.
+    (EMAIL_BACKEND and MAILERS are set to locmem). We capture originals
+    here so providers can use them for auto-detection.
     """
     global _context
     try:
         _context = {
             "original_email_backend": getattr(settings, "EMAIL_BACKEND", None),
+            "original_mailers": getattr(settings, "MAILERS", None),
         }
     except Exception:
         # Settings may not be configured yet

--- a/src/django_testcontainers_plus/runner.py
+++ b/src/django_testcontainers_plus/runner.py
@@ -37,9 +37,10 @@ class TestcontainersRunner(DiscoverRunner):
     def setup_test_environment(self, **kwargs: Any) -> None:
         """Set up test environment and start containers."""
         # Capture original settings before Django's setup_test_environment
-        # overwrites them (e.g. EMAIL_BACKEND is set to locmem)
+        # overwrites them (EMAIL_BACKEND and MAILERS are set to locmem)
         context = {
             "original_email_backend": getattr(settings, "EMAIL_BACKEND", None),
+            "original_mailers": getattr(settings, "MAILERS", None),
         }
 
         super().setup_test_environment(**kwargs)

--- a/tests/test_mailhog_provider.py
+++ b/tests/test_mailhog_provider.py
@@ -305,7 +305,7 @@ class TestMailhogProvider:
                 "marketing": {
                     "BACKEND": "example.third.party.EmailBackend",
                 },
-            }
+            },
         )
 
         provider = MailhogProvider()

--- a/tests/test_mailhog_provider.py
+++ b/tests/test_mailhog_provider.py
@@ -294,8 +294,10 @@ class TestMailhogProvider:
         assert updates["EMAIL_PORT"] == 1025
 
     def test_update_settings_with_mailers(self):
-        """Test that MAILERS is patched instead of deprecated EMAIL_* keys."""
+        """Test that MAILERS and EMAIL_* both point at Mailhog."""
         settings = MockSettings(
+            EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
+            EMAIL_HOST="smtp.example.com",
             MAILERS={
                 "default": {
                     "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
@@ -314,8 +316,11 @@ class TestMailhogProvider:
 
         updates = provider.update_settings(mock_container, settings, {})
 
-        assert "EMAIL_BACKEND" not in updates
-        assert "EMAIL_HOST" not in updates
+        assert updates["EMAIL_BACKEND"] == "django.core.mail.backends.smtp.EmailBackend"
+        assert updates["EMAIL_HOST"] == "127.0.0.1"
+        assert updates["EMAIL_PORT"] == 32768
+        assert updates["EMAIL_USE_TLS"] is False
+        assert updates["EMAIL_USE_SSL"] is False
         assert updates["MAILERS"]["default"]["BACKEND"] == (
             "django.core.mail.backends.smtp.EmailBackend"
         )

--- a/tests/test_mailhog_provider.py
+++ b/tests/test_mailhog_provider.py
@@ -111,6 +111,94 @@ class TestMailhogProvider:
 
         assert provider.can_auto_detect(settings, context={}) is True
 
+    def test_can_auto_detect_mailers_smtp_backend(self):
+        """Test auto-detection from Django 6.1 MAILERS smtp backend."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+                    "OPTIONS": {"host": "smtp.example.com"},
+                }
+            }
+        )
+        provider = MailhogProvider()
+
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_mailers_host_no_backend(self):
+        """Test auto-detection when MAILERS OPTIONS host is set without BACKEND."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "OPTIONS": {"host": "smtp.example.com"},
+                }
+            }
+        )
+        provider = MailhogProvider()
+
+        assert provider.can_auto_detect(settings) is True
+
+    def test_can_auto_detect_mailers_locmem_backend(self):
+        """Test that MAILERS locmem backend is skipped."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+                }
+            }
+        )
+        provider = MailhogProvider()
+
+        assert provider.can_auto_detect(settings) is False
+
+    def test_can_auto_detect_mailers_console_backend(self):
+        """Test that MAILERS console backend is skipped."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.console.EmailBackend",
+                }
+            }
+        )
+        provider = MailhogProvider()
+
+        assert provider.can_auto_detect(settings) is False
+
+    def test_can_auto_detect_uses_context_mailers_over_settings(self):
+        """Test that context original_mailers is used over overwritten settings."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+                }
+            }
+        )
+        context = {
+            "original_mailers": {
+                "default": {
+                    "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+                    "OPTIONS": {"host": "smtp.example.com"},
+                }
+            }
+        }
+        provider = MailhogProvider()
+
+        assert provider.can_auto_detect(settings, context) is True
+
+    def test_can_auto_detect_mailers_takes_precedence_over_email_backend(self):
+        """Test that MAILERS backend is preferred over EMAIL_BACKEND."""
+        settings = MockSettings(
+            EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.console.EmailBackend",
+                }
+            },
+        )
+        provider = MailhogProvider()
+
+        assert provider.can_auto_detect(settings) is False
+
     @patch("django_testcontainers_plus.providers.mailhog.DockerContainer")
     def test_get_container_defaults(self, mock_docker_container):
         """Test container creation with default config."""
@@ -204,6 +292,60 @@ class TestMailhogProvider:
 
         assert isinstance(updates["EMAIL_PORT"], int)
         assert updates["EMAIL_PORT"] == 1025
+
+    def test_update_settings_with_mailers(self):
+        """Test that MAILERS is patched instead of deprecated EMAIL_* keys."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+                },
+                "marketing": {
+                    "BACKEND": "example.third.party.EmailBackend",
+                },
+            }
+        )
+
+        provider = MailhogProvider()
+        mock_container = Mock()
+        mock_container.get_container_host_ip = Mock(return_value="127.0.0.1")
+        port_map = {1025: 32768, 8025: 32769}
+        mock_container.get_exposed_port = Mock(side_effect=lambda p: port_map[p])
+
+        updates = provider.update_settings(mock_container, settings, {})
+
+        assert "EMAIL_BACKEND" not in updates
+        assert "EMAIL_HOST" not in updates
+        assert updates["MAILERS"]["default"]["BACKEND"] == (
+            "django.core.mail.backends.smtp.EmailBackend"
+        )
+        assert updates["MAILERS"]["default"]["OPTIONS"]["host"] == "127.0.0.1"
+        assert updates["MAILERS"]["default"]["OPTIONS"]["port"] == 32768
+        assert updates["MAILERS"]["default"]["OPTIONS"]["use_tls"] is False
+        assert updates["MAILERS"]["default"]["OPTIONS"]["use_ssl"] is False
+        assert updates["MAILHOG_API_URL"] == "http://127.0.0.1:32769/api/v2"
+        assert "marketing" not in updates["MAILERS"]
+
+    def test_update_settings_mailers_port_type(self):
+        """Test that MAILERS OPTIONS port is an integer."""
+        settings = MockSettings(
+            MAILERS={
+                "default": {
+                    "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+                }
+            }
+        )
+
+        provider = MailhogProvider()
+        mock_container = Mock()
+        mock_container.get_container_host_ip = Mock(return_value="localhost")
+        port_map = {1025: "1025", 8025: "8025"}
+        mock_container.get_exposed_port = Mock(side_effect=lambda p: port_map[p])
+
+        updates = provider.update_settings(mock_container, settings, {})
+
+        assert isinstance(updates["MAILERS"]["default"]["OPTIONS"]["port"], int)
+        assert updates["MAILERS"]["default"]["OPTIONS"]["port"] == 1025
 
     def test_get_default_config(self):
         """Test default configuration."""

--- a/uv.lock
+++ b/uv.lock
@@ -343,7 +343,7 @@ toml = [
 
 [[package]]
 name = "django"
-version = "5.2.11"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.12'",
@@ -353,14 +353,14 @@ dependencies = [
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/f2/3e57ef696b95067e05ae206171e47a8e53b9c84eec56198671ef9eaa51a6/django-5.2.11.tar.gz", hash = "sha256:7f2d292ad8b9ee35e405d965fbbad293758b858c34bbf7f3df551aeeac6f02d3", size = 10885017, upload-time = "2026-02-03T13:52:50.554Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a7/2b112ab430575bf3135b8304ac372248500d99c352f777485f53fdb9537e/django-5.2.11-py3-none-any.whl", hash = "sha256:e7130df33ada9ab5e5e929bc19346a20fe383f5454acb2cc004508f242ee92c0", size = 8291375, upload-time = "2026-02-03T13:52:42.47Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]
 name = "django"
-version = "6.0.2"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -370,9 +370,9 @@ dependencies = [
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/3e/a1c4207c5dea4697b7a3387e26584919ba987d8f9320f59dc0b5c557a4eb/django-6.0.2.tar.gz", hash = "sha256:3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7", size = 10886874, upload-time = "2026-02-03T13:50:31.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/ba/a6e2992bc5b8c688249c00ea48cb1b7a9bc09839328c81dc603671460928/django-6.0.2-py3-none-any.whl", hash = "sha256:610dd3b13d15ec3f1e1d257caedd751db8033c5ad8ea0e2d1219a8acf446ecc6", size = 8339381, upload-time = "2026-02-03T13:50:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -380,8 +380,8 @@ name = "django-stubs"
 version = "5.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "django-stubs-ext" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "types-pyyaml" },
@@ -397,8 +397,8 @@ name = "django-stubs-ext"
 version = "5.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/03/9c2be939490d2282328db4611bc5956899f5ff7eabc3e88bd4b964a87373/django_stubs_ext-5.2.9.tar.gz", hash = "sha256:6db4054d1580657b979b7d391474719f1a978773e66c7070a5e246cd445a25a9", size = 6497, upload-time = "2026-01-20T23:58:59.462Z" }
@@ -411,8 +411,8 @@ name = "django-testcontainers-plus"
 version = "0.1.5"
 source = { editable = "." }
 dependencies = [
-    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pytest" },
     { name = "testcontainers" },
 ]
@@ -451,7 +451,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.28.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28.0" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.28.0" },
-    { name = "django", specifier = ">=4.2" },
+    { name = "django", specifier = ">=5.2" },
     { name = "django-stubs", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },


### PR DESCRIPTION
## Summary
- Raise the Django floor to 5.2 LTS and declare support for 5.2, 6.0, and 6.1 (Python 3.10–3.14 unchanged).
- Test compatible Django × Python pairs in CI instead of only the lockfile-resolved version.
- Detect and patch Django 6.1 `MAILERS` in Mailhog, while still pointing deprecated `EMAIL_*` settings at the container so leftover SMTP backends cannot send real email during tests.

## Test plan
- [ ] CI matrix jobs pass for 3.10/5.2, 3.11/5.2, 3.12/5.2, 3.12/6.0, 3.12/6.1, 3.13/6.1, 3.14/6.1
- [ ] Mailhog unit tests cover `MAILERS` auto-detection and dual `MAILERS` + `EMAIL_*` settings updates
- [ ] Confirm PyPI classifiers show Django 5.2 / 6.0 / 6.1 after publish


Made with [Cursor](https://cursor.com)