### PR TITLE
Make docs fetchable for coding agents

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,16 @@ jobs:
           version: "latest"
 
       - name: Install docs dependencies
-        run: uv pip install --system mkdocs-material "mkdocstrings[python]"
+        run: uv pip install --system ".[docs]"
 
       - name: Build docs
         run: mkdocs build --clean
+
+      - name: Check LLM-friendly outputs
+        run: |
+          test -f site/llms.txt
+          test -f site/llms-full.txt
+          if grep -q '::: django_testcontainers_plus' site/pages/api-reference/providers/index.md; then
+            echo "API markdown still contains mkdocstrings directives" >&2
+            exit 1
+          fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,8 @@
+# Read the Docs serves llms.txt and llms-full.txt from the default version
+# at https://<project>.readthedocs.io/llms.txt (and llms-full.txt).
+# The mkdocs-llmstxt plugin writes those files during the MkDocs build.
+# Dashboard exact redirects from /llms.txt -> /en/latest/llms.txt are only
+# needed if you want a version other than the project's default.
 version: 2
 
 build:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A plug-and-play testcontainers integration for Django
 [![PyPI version](https://img.shields.io/pypi/v/django-testcontainers-plus.svg)](https://pypi.org/project/django-testcontainers-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+**Docs:** [django-testcontainers-plus.readthedocs.io](https://django-testcontainers-plus.readthedocs.io/) · [llms.txt](https://django-testcontainers-plus.readthedocs.io/llms.txt) · [llms-full.txt](https://django-testcontainers-plus.readthedocs.io/llms-full.txt)
+
 ## Why Django Testcontainers Plus?
 
 Testing Django applications often requires external services like PostgreSQL, Redis, or S3. Django Testcontainers Plus makes this effortless by:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Django Testcontainers Plus
 
-A plug-and-play testcontainers integration for Django
+Django **test runner** and **pytest** plugin for [Testcontainers](https://testcontainers.com/). It auto-starts Postgres, MySQL, Redis, S3, and Mailhog from your existing `DATABASES` / `CACHES` / `STORAGES` settings so tests run against real Docker services without a docker-compose test stack.
 
 [![PyPI version](https://img.shields.io/pypi/v/django-testcontainers-plus.svg)](https://pypi.org/project/django-testcontainers-plus/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -9,14 +9,18 @@ A plug-and-play testcontainers integration for Django
 
 ## Why Django Testcontainers Plus?
 
-Testing Django applications often requires external services like PostgreSQL, Redis, or S3. Django Testcontainers Plus makes this effortless by:
+- **Zero configuration**: Detects engines from Django settings (no extra TOML required to start)
+- **Django test runner and pytest-django**: `TEST_RUNNER` or a pytest plugin, not pytest-only
+- **Beyond Postgres**: MySQL/MariaDB, Redis, S3-compatible storage, Mailhog
+- **No docker-compose for tests**: Containers start, settings are rewritten with host/port, then torn down
 
-- **Zero Configuration**: Automatically detects your database and service needs from Django settings
-- **Plug and Play**: Install, add to settings, and go - no manual container management
-- **Database Agnostic**: Supports PostgreSQL, MySQL, MariaDB, and more
-- **Beyond Databases**: Redis for caching, S3-compatible storage, and other services
-- **Dual Compatibility**: Works with both Django's test runner and pytest
-- **Smart Defaults**: Sensible defaults with full customization when needed
+## Compared to
+
+| Approach | Use when |
+|---|---|
+| **django-testcontainers-plus** | You want Django `manage.py test` *and* pytest, with auto-detect from existing settings |
+| [pytest-testcontainers-django](https://pypi.org/project/pytest-testcontainers-django/) | You are pytest-only and want to start Postgres/Redis before Django imports settings |
+| Raw [testcontainers](https://pypi.org/project/testcontainers/) | You want to wire containers and Django `DATABASES` yourself |
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,33 @@ Testing Django applications often requires real external services like PostgreSQ
 
 ## Quick Look
 
+Set the Django test runner, configure `DATABASES` as usual (no host or port), and run tests:
+
+```python title="settings.py"
+TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'myapp',
+    }
+}
+```
+
+```bash
+python manage.py test
+```
+
+For pytest, register the plugin in `conftest.py` instead of setting `TEST_RUNNER`:
+
+```python title="conftest.py"
+pytest_plugins = ['django_testcontainers_plus.pytest_plugin']
+```
+
+```bash
+pytest
+```
+
 === "Django Test Runner"
 
     ```python title="settings.py"
@@ -105,3 +132,4 @@ Testing Django applications often requires real external services like PostgreSQ
 
 - [Quick Start](pages/getting-started/quickstart.md) - Get up and running in minutes
 - [Configuration](pages/user-guide/configuration.md) - Customize container images, credentials, and more
+- LLM-friendly copies: [llms.txt](https://django-testcontainers-plus.readthedocs.io/llms.txt) (index) and [llms-full.txt](https://django-testcontainers-plus.readthedocs.io/llms-full.txt) (full docs)

--- a/docs/pages/getting-started/installation.md
+++ b/docs/pages/getting-started/installation.md
@@ -8,6 +8,14 @@
 
 ## Basic Installation
 
+Install with uv or pip. PostgreSQL support is included by default.
+
+```bash
+uv add django-testcontainers-plus
+# or
+pip install django-testcontainers-plus
+```
+
 === "uv (recommended)"
 
     ```bash
@@ -20,11 +28,9 @@
     pip install django-testcontainers-plus
     ```
 
-PostgreSQL support is included by default - no extras needed.
-
 ## Optional Extras
 
-Some providers require additional client libraries. Install them with the appropriate extra:
+Some providers require additional client libraries. Install them with the appropriate extra, for example `pip install django-testcontainers-plus[mysql]`, `[redis]`, `[s3]`, or `[all]`.
 
 === "MySQL / MariaDB"
 

--- a/docs/pages/help/changelog.md
+++ b/docs/pages/help/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - LLM-friendly documentation: `llms.txt`, `llms-full.txt`, and per-page Markdown copies via mkdocs-llmstxt
 
+### Changed
+- README and PyPI description/keywords so coding agents can distinguish this package from pytest-only Testcontainers plugins
+
 ## [0.1.6] - Latest
 
 ### Changed

--- a/docs/pages/help/changelog.md
+++ b/docs/pages/help/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- LLM-friendly documentation: `llms.txt`, `llms-full.txt`, and per-page Markdown copies via mkdocs-llmstxt
+
 ## [0.1.6] - Latest
 
 ### Changed

--- a/docs/pages/help/contributing.md
+++ b/docs/pages/help/contributing.md
@@ -73,6 +73,17 @@ class MongoDBProvider(ContainerProvider):
 4. Add tests in `tests/test_mongodb_provider.py`
 5. Add documentation in `docs/pages/providers/mongodb.md`
 
+## Documentation
+
+Build the docs locally with:
+
+```bash
+uv sync --extra docs
+uv run mkdocs build
+```
+
+The build writes `site/llms.txt`, `site/llms-full.txt`, and Markdown copies of each page for coding agents. Read the Docs serves `llms.txt` and `llms-full.txt` from the project's default version at the documentation domain root.
+
 ## Submitting a Pull Request
 
 1. Fork the repository

--- a/docs/pages/providers/redis.md
+++ b/docs/pages/providers/redis.md
@@ -20,6 +20,21 @@ The provider activates automatically from any of these settings:
 
 ## Minimal Setup
 
+The most common setup is Django's Redis cache backend. Set the test runner (or the pytest plugin) and a `CACHES` backend whose name contains `redis`:
+
+```python title="settings.py"
+TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': 'redis://localhost:6379/0',
+    }
+}
+```
+
+Celery (`CELERY_BROKER_URL` starting with `redis://`) and Redis sessions (`SESSION_ENGINE`) are also auto-detected.
+
 === "Django Cache"
 
     ```python title="settings.py"

--- a/docs/pages/providers/s3.md
+++ b/docs/pages/providers/s3.md
@@ -27,6 +27,22 @@ The provider activates automatically from any of these settings:
 
 ## Minimal Setup
 
+The usual setup is Django 4.2+ `STORAGES` with `s3boto3` plus a bucket name:
+
+```python title="settings.py"
+TEST_RUNNER = 'django_testcontainers_plus.runner.TestcontainersRunner'
+
+STORAGES = {
+    'default': {
+        'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+    }
+}
+
+AWS_STORAGE_BUCKET_NAME = 'test-uploads'
+```
+
+Legacy `DEFAULT_FILE_STORAGE` is also detected.
+
 === "STORAGES"
 
     ```python title="settings.py"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,32 @@ plugins:
             show_symbol_type_heading: true
             show_symbol_type_toc: true
             members_order: source
+  - llmstxt:
+      markdown_description: >
+        Plug-and-play Testcontainers for Django. Prefer Quick Start then
+        Configuration. Providers auto-detect from DATABASES / CACHES / STORAGES.
+      full_output: llms-full.txt
+      base_url: !ENV [READTHEDOCS_CANONICAL_URL, "https://django-testcontainers-plus.readthedocs.io/en/latest/"]
+      sections:
+        Getting Started:
+          - index.md: Project overview and install
+          - pages/getting-started/installation.md
+          - pages/getting-started/quickstart.md
+        User Guide:
+          - pages/user-guide/configuration.md
+          - pages/user-guide/how-it-works.md
+        Providers:
+          - pages/providers/postgres.md
+          - pages/providers/mysql.md
+          - pages/providers/redis.md
+          - pages/providers/s3.md
+        API Reference:
+          - pages/api-reference/index.md
+          - pages/api-reference/providers.md
+        Optional:
+          - pages/help/troubleshooting.md
+          - pages/help/contributing.md
+          - pages/help/changelog.md
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
 docs = [
     "mkdocs-material>=9.0.0",
     "mkdocstrings[python]>=0.25.0",
+    "mkdocs-llmstxt>=0.3.0",
 ]
 mysql = [
     "mysql-connector-python>=8.0.0",
@@ -67,6 +68,7 @@ all = [
 Homepage = "https://github.com/woodywoodster/django-testcontainers-plus"
 Repository = "https://github.com/woodywoodster/django-testcontainers-plus"
 Documentation = "https://django-testcontainers-plus.readthedocs.io/"
+"Documentation (LLM)" = "https://django-testcontainers-plus.readthedocs.io/llms.txt"
 Issues = "https://github.com/woodywoodster/django-testcontainers-plus/issues"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "django-testcontainers-plus"
 version = "0.1.6"
-description = "A plug-and-play testcontainers integration for Django - supports databases, Redis, S3, and more"
+description = "Django test runner and pytest plugin for Testcontainers. Auto-starts Postgres, MySQL, Redis, and S3 from Django settings—no docker-compose for tests."
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
     { name = "Andrew Woodward", email = "arwoodward553@gmail.com" }
 ]
 requires-python = ">=3.10"
-keywords = ["django", "testcontainers", "testing", "docker", "containers", "postgres", "mysql", "redis", "mailhog", "email", "s3", "boto3", "django-storages"]
+keywords = ["django", "testcontainers", "testing", "docker", "containers", "postgres", "mysql", "redis", "mailhog", "email", "s3", "boto3", "django-storages", "pytest-django", "django-test-runner", "integration-testing"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Django",

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.76"
 source = { registry = "https://pypi.org/simple" }
@@ -433,6 +446,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
@@ -453,6 +467,7 @@ requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.28.0" },
     { name = "django", specifier = ">=5.2" },
     { name = "django-stubs", marker = "extra == 'dev'", specifier = ">=4.2.0" },
+    { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.3.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
@@ -650,6 +665,31 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/ab/d1297139c0e2ceb151ae564c8c4f57ac0155d8f1f8b4cbd5d6523c82ea36/markdownify-1.2.3.tar.gz", hash = "sha256:1a176f05522c8a2cb1dd3ab9d307dcdadbed5c26ae717855bfc42b3b6d38d937", size = 18852, upload-time = "2026-06-30T20:27:39.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/10/fa543d484e8b1199243fe20eedd02cc5af050edebce98a7293a5773df592/markdownify-1.2.3-py3-none-any.whl", hash = "sha256:a189a0bedfd14009030fde5f85bb6f77c56897cb839b5c25315dd7d4e3e290ba", size = 15732, upload-time = "2026-06-30T20:27:38.094Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -735,6 +775,41 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -793,6 +868,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
 ]
 
 [[package]]
@@ -1259,6 +1349,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1421,6 +1520,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Generate `llms.txt`, `llms-full.txt`, and per-page Markdown copies so agents can load the docs without HTML chrome.
- Install the docs extra in CI and advertise LLM URLs from README, PyPI, and the docs home.
- Tighten README/PyPI description and add a short compared-to table so agents can distinguish this package from pytest-only Testcontainers plugins.

## Test plan
- [ ] Docs workflow builds and asserts `site/llms.txt` exists
- [ ] After merge, `https://django-testcontainers-plus.readthedocs.io/llms.txt` returns the index
- [ ] `https://django-testcontainers-plus.readthedocs.io/en/latest/llms.txt` matches